### PR TITLE
docs: fix stale references and update documentation accuracy

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -81,7 +81,7 @@ Automatically apply relevant labels based on content analysis:
 
 - **Type Labels**: `bug`, `feature`, `documentation`, `enhancement`, `refactor`
 - **Priority Labels**: `priority:low`, `priority:medium`, `priority:high`, `priority:critical`
-- **Component Labels**: `http-gen`, `openapi`, `oneof-helper`, `validation`, `testing`
+- **Component Labels**: `http-gen`, `openapi`, `validation`, `testing`
 - **Status Labels**: `needs-investigation`, `ready-to-implement`, `blocked`
 
 ## Implementation Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,7 @@ sebuf stands on the shoulders of giants. We build upon and integrate with an inc
 ### Validation Ecosystem  
 - **[protovalidate](https://github.com/bufbuild/protovalidate)** by Buf - The modern validation framework that powers our automatic request validation. Built on CEL for flexibility and performance.
 - **[Common Expression Language (CEL)](https://github.com/google/cel-go)** by Google - The expression language that enables powerful custom validation rules in protovalidate.
-- **[buf.validate](https://buf.build/bufbuild/protovalidate)** - The proto definitions that provide the validation annotations we alias as `sebuf.validate`.
+- **[buf.validate](https://buf.build/bufbuild/protovalidate)** - The proto definitions that provide the validation annotations used directly in sebuf (e.g., `buf.validate.field`).
 
 ### API Documentation
 - **[OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0)** - The industry standard for REST API documentation that our OpenAPI generator targets.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,11 +176,9 @@ Understanding the project structure helps you contribute effectively:
 ```
 sebuf/
 ├── cmd/                           # Command-line tools
-│   ├── protoc-gen-go-oneof-helper/   # Oneof helper generator
-│   ├── protoc-gen-go-http/           # HTTP handler generator  
+│   ├── protoc-gen-go-http/           # HTTP handler generator
 │   └── protoc-gen-openapiv3/         # OpenAPI spec generator
 ├── internal/                      # Internal packages
-│   ├── oneofhelper/                  # Oneof helper logic
 │   ├── httpgen/                      # HTTP generation logic
 │   └── openapiv3/                    # OpenAPI generation logic
 ├── proto/                         # Protobuf definitions
@@ -390,7 +388,6 @@ Any additional information that would be helpful for reviewers.
 make test
 
 # Run specific test suites
-go test ./internal/oneofhelper/...
 go test ./internal/httpgen/...
 go test ./internal/openapiv3/...
 
@@ -398,7 +395,8 @@ go test ./internal/openapiv3/...
 make test-coverage
 
 # Update golden files (when output intentionally changes)
-UPDATE_GOLDEN=1 go test ./internal/oneofhelper/
+UPDATE_GOLDEN=1 go test ./internal/httpgen/
+UPDATE_GOLDEN=1 go test ./internal/openapiv3/
 ```
 
 ### Adding New Tests
@@ -406,13 +404,13 @@ UPDATE_GOLDEN=1 go test ./internal/oneofhelper/
 **Golden File Tests:**
 ```bash
 # Add new test proto file
-echo 'syntax = "proto3"; ...' > internal/oneofhelper/testdata/proto/new_test.proto
+echo 'syntax = "proto3"; ...' > internal/httpgen/testdata/proto/new_test.proto
 
 # Add expected output
-echo '// Expected generated code' > internal/oneofhelper/testdata/golden/new_test_helpers.pb.go
+echo '// Expected generated code' > internal/httpgen/testdata/golden/new_test_http.pb.go
 
 # Update test to include new file
-# Edit internal/oneofhelper/exhaustive_golden_test.go
+# Edit internal/httpgen/exhaustive_golden_test.go
 ```
 
 **Unit Tests:**

--- a/docs/http-generation.md
+++ b/docs/http-generation.md
@@ -75,20 +75,23 @@ service UserService {
   rpc CreateUser(CreateUserRequest) returns (User) {
     option (sebuf.http.config) = {
       path: "/users"
+      method: HTTP_METHOD_POST
     };
   }
-  
+
   // Get user by ID
   rpc GetUser(GetUserRequest) returns (User) {
     option (sebuf.http.config) = {
-      path: "/users/get"
+      path: "/users/{id}"
+      method: HTTP_METHOD_GET
     };
   }
-  
+
   // List all users
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option (sebuf.http.config) = {
       path: "/users"
+      method: HTTP_METHOD_GET
     };
   }
 }
@@ -252,10 +255,10 @@ func main() {
     // Start server
     fmt.Println("Server starting on :8080")
     fmt.Println("Endpoints:")
-    fmt.Println("  POST   /api/v1/users      - Create user")
-    fmt.Println("  POST   /api/v1/users/get - Get user")
-    fmt.Println("  POST   /api/v1/users      - List users")
-    
+    fmt.Println("  POST   /api/v1/users       - Create user")
+    fmt.Println("  GET    /api/v1/users/{id}  - Get user")
+    fmt.Println("  GET    /api/v1/users       - List users")
+
     log.Fatal(http.ListenAndServe(":8080", mux))
 }
 ```
@@ -272,18 +275,11 @@ curl -X POST http://localhost:8080/api/v1/users \
     "department": "Engineering"
   }'
 
-# Get a user  
-curl -X POST http://localhost:8080/api/v1/users/get \
-  -H "Content-Type: application/json" \
-  -d '{"id": "123"}'
+# Get a user
+curl -X GET http://localhost:8080/api/v1/users/123
 
 # List users with filter
-curl -X POST http://localhost:8080/api/v1/users \
-  -H "Content-Type: application/json" \
-  -d '{
-    "page_size": 10,
-    "department_filter": "Engineering"
-  }'
+curl -X GET "http://localhost:8080/api/v1/users?page_size=10&department_filter=Engineering"
 ```
 
 ## HTTP Annotations
@@ -667,8 +663,7 @@ service AuthenticatedAPI {
         description: "API version"
         type: "string"
         required: false
-        default: "v1"
-        enum: ["v1", "v2", "v3"]
+        example: "v1"
       }
     ]
   };
@@ -1179,24 +1174,36 @@ message UploadFileRequest {
 ### 1. Consistent URL Design
 
 ```protobuf
-// Good: RESTful paths
+// Good: RESTful paths with HTTP methods
 service UserService {
   option (sebuf.http.service_config) = { base_path: "/api/v1" };
-  
+
   rpc CreateUser(CreateUserRequest) returns (User) {
-    option (sebuf.http.config) = { path: "/users" };
+    option (sebuf.http.config) = {
+      path: "/users"
+      method: HTTP_METHOD_POST
+    };
   }
-  
+
   rpc GetUser(GetUserRequest) returns (User) {
-    option (sebuf.http.config) = { path: "/users/get" };
+    option (sebuf.http.config) = {
+      path: "/users/{id}"
+      method: HTTP_METHOD_GET
+    };
   }
-  
+
   rpc UpdateUser(UpdateUserRequest) returns (User) {
-    option (sebuf.http.config) = { path: "/users/update" };
+    option (sebuf.http.config) = {
+      path: "/users/{id}"
+      method: HTTP_METHOD_PUT
+    };
   }
-  
+
   rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
-    option (sebuf.http.config) = { path: "/users/delete" };
+    option (sebuf.http.config) = {
+      path: "/users/{id}"
+      method: HTTP_METHOD_DELETE
+    };
   }
 }
 ```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -182,15 +182,12 @@ service APIService {
         description: "Tenant identifier"
         type: "integer"
         required: true
-        minimum: 1
-        maximum: 999999
       },
       {
         name: "X-Debug-Mode"
         description: "Enable debug mode"
         type: "boolean"
         required: false
-        default: "false"
       }
     ]
   };
@@ -213,10 +210,9 @@ rpc CreateResource(CreateResourceRequest) returns (Resource) {
       },
       {
         name: "X-Idempotency-Key"
+        description: "Idempotency key for safe retries"
         type: "string"
         required: true
-        min_length: 16
-        max_length: 64
       }
     ]
   };
@@ -228,8 +224,8 @@ rpc CreateResource(CreateResourceRequest) returns (Resource) {
 | Type | Formats | Description |
 |------|---------|-------------|
 | `string` | `uuid`, `email`, `date-time`, `date`, `time` | Text with optional format validation |
-| `integer` | - | Whole numbers with optional min/max constraints |
-| `number` | - | Decimal numbers with optional min/max constraints |
+| `integer` | - | Whole numbers |
+| `number` | - | Decimal numbers |
 | `boolean` | - | `true` or `false` values |
 | `array` | - | Comma-separated values |
 
@@ -243,40 +239,45 @@ service SecureAPI {
       // UUID validation
       {
         name: "X-Trace-ID"
+        description: "Trace ID for request tracing"
         type: "string"
         format: "uuid"
         required: true
+        example: "123e4567-e89b-12d3-a456-426614174000"
       },
       // Email validation
       {
         name: "X-Admin-Email"
+        description: "Admin contact email"
         type: "string"
         format: "email"
         required: false
+        example: "admin@example.com"
       },
       // Date-time validation
       {
         name: "X-Request-Time"
+        description: "Request timestamp"
         type: "string"
         format: "date-time"
         required: true
+        example: "2024-01-15T10:30:00Z"
       },
-      // Integer with constraints
+      // Integer type
       {
         name: "X-Rate-Limit"
+        description: "Rate limit override"
         type: "integer"
         required: false
-        minimum: 1
-        maximum: 1000
-        default: "100"
+        example: "100"
       },
-      // Enum-like validation
+      // String type
       {
         name: "X-API-Version"
+        description: "API version"
         type: "string"
         required: false
-        enum: ["v1", "v2", "v3"]
-        default: "v2"
+        example: "v2"
       },
       // Array type
       {
@@ -284,6 +285,7 @@ service SecureAPI {
         type: "array"
         required: false
         description: "Comma-separated feature flags"
+        example: "feature1,feature2"
       }
     ]
   };


### PR DESCRIPTION
## Summary

- Remove all references to the removed `oneof-helper` plugin from documentation
- Fix incorrect claim about `sebuf.validate` aliasing in CLAUDE.md
- Remove non-existent header properties from validation documentation
- Update examples to show modern RESTful patterns with HTTP methods

## Changes

### Removed oneof-helper references (removed feature)
- **CONTRIBUTING.md**: Removed from repository structure, test commands, and golden file examples
- **.claude/commands/create-issue.md**: Removed from component labels

### Fixed inaccurate documentation
- **CLAUDE.md**: Corrected claim that buf.validate annotations are "aliased as sebuf.validate" - they are used directly
- **docs/validation.md**: Removed non-existent header properties (`minimum`, `maximum`, `default`, `enum`, `min_length`, `max_length`) that don't exist in headers.proto

### Updated examples for HTTP method support
- **docs/http-generation.md**: Updated Quick Start and Best Practices to show RESTful patterns with `HTTP_METHOD_GET`, `HTTP_METHOD_POST`, etc.
- **docs/getting-started.md**: Added `GetUser` RPC example to demonstrate HTTP verb support

## Test plan

- [ ] Review all modified documentation files for consistency
- [ ] Verify examples match actual proto definitions in headers.proto
- [ ] Cross-reference with code to ensure accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)