### PR TITLE
feat(ts-client): support message-only protos and proto field names

### DIFF
--- a/cmd/protoc-gen-ts-client/main.go
+++ b/cmd/protoc-gen-ts-client/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/types/pluginpb"
 
@@ -8,11 +10,14 @@ import (
 )
 
 func main() {
-	options := protogen.Options{}
+	var flags flag.FlagSet
+	var fieldNames string
+	flags.StringVar(&fieldNames, "field_names", "json", "TypeScript field naming: json or proto")
+	options := protogen.Options{ParamFunc: flags.Set}
 
 	options.Run(func(plugin *protogen.Plugin) error {
 		plugin.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
-		gen := tsclientgen.New(plugin)
+		gen := tsclientgen.NewWithOptions(plugin, tsclientgen.Options{FieldNames: fieldNames})
 		return gen.Generate()
 	})
 }

--- a/internal/tsclientgen/generator.go
+++ b/internal/tsclientgen/generator.go
@@ -1,6 +1,7 @@
 package tsclientgen
 
 import (
+	"fmt"
 	"net/http"
 
 	"google.golang.org/protobuf/compiler/protogen"
@@ -12,20 +13,41 @@ import (
 // Generator handles TypeScript HTTP client code generation for protobuf services.
 type Generator struct {
 	plugin *protogen.Plugin
+	opts   Options
 	// ctx carries the emission state (self module + import tracker) for the
 	// service file currently being written.
 	ctx *tscommon.EmitContext
 }
 
+const protoFieldNames = "proto"
+
+// Options configures TypeScript HTTP client generation.
+type Options struct {
+	// FieldNames accepts "json" (the default) or "proto".
+	FieldNames string
+}
+
 // New creates a new TypeScript client generator.
 func New(plugin *protogen.Plugin) *Generator {
-	return &Generator{plugin: plugin}
+	return NewWithOptions(plugin, Options{})
+}
+
+// NewWithOptions creates a TypeScript client generator with explicit options.
+func NewWithOptions(plugin *protogen.Plugin, opts Options) *Generator {
+	return &Generator{plugin: plugin, opts: opts}
 }
 
 // Generate emits one canonical type module per proto file, a shared errors
 // module, and one slimmed client module per service file.
 func (g *Generator) Generate() error {
+	if g.opts.FieldNames != "" && g.opts.FieldNames != "json" && g.opts.FieldNames != protoFieldNames {
+		return fmt.Errorf("field_names must be json or proto, got %q", g.opts.FieldNames)
+	}
 	return g.generateModules()
+}
+
+func (g *Generator) useProtoFieldNames() bool {
+	return g.opts.FieldNames == protoFieldNames
 }
 
 func (g *Generator) generateServiceClient(p printer, service *protogen.Service) error {
@@ -365,6 +387,9 @@ func (g *Generator) generateURLBuilding(p printer, cfg *rpcMethodConfig) {
 	// Path parameter substitution
 	for _, param := range cfg.pathParams {
 		jsonName := snakeToLowerCamel(param)
+		if g.useProtoFieldNames() {
+			jsonName = param
+		}
 		p(`    path = path.replace("{%s}", encodeURIComponent(String(req.%s)));`, param, jsonName)
 	}
 
@@ -373,10 +398,14 @@ func (g *Generator) generateURLBuilding(p printer, cfg *rpcMethodConfig) {
 	if (cfg.httpMethod == "GET" || cfg.httpMethod == "DELETE") && len(cfg.queryParams) > 0 {
 		p("    const params = new URLSearchParams();")
 		for _, qp := range cfg.queryParams {
+			requestFieldName := qp.FieldJSONName
+			if qp.Field != nil && g.useProtoFieldNames() {
+				requestFieldName = string(qp.Field.Desc.Name())
+			}
 			// Handle repeated fields: use forEach + append for multi-value params
 			if qp.Field != nil && qp.Field.Desc.IsList() {
 				p("    if (req.%s && req.%s.length > 0) req.%s.forEach(v => params.append(\"%s\", String(v)));",
-					qp.FieldJSONName, qp.FieldJSONName, qp.FieldJSONName, qp.ParamName)
+					requestFieldName, requestFieldName, requestFieldName, qp.ParamName)
 				continue
 			}
 
@@ -390,11 +419,11 @@ func (g *Generator) generateURLBuilding(p printer, cfg *rpcMethodConfig) {
 			if check == "" {
 				// bool: only add if true (undefined is already falsy)
 				p("    if (req.%s) params.set(\"%s\", String(req.%s));",
-					qp.FieldJSONName, qp.ParamName, qp.FieldJSONName)
+					requestFieldName, qp.ParamName, requestFieldName)
 			} else {
 				// Guard against undefined/null before zero-value check
 				p("    if (req.%s != null && req.%s%s) params.set(\"%s\", String(req.%s));",
-					qp.FieldJSONName, qp.FieldJSONName, check, qp.ParamName, qp.FieldJSONName)
+					requestFieldName, requestFieldName, check, qp.ParamName, requestFieldName)
 			}
 		}
 		p(`    const url = this.baseURL + path + (params.toString() ? "?" + params.toString() : "");`)

--- a/internal/tsclientgen/modules.go
+++ b/internal/tsclientgen/modules.go
@@ -11,7 +11,9 @@ import (
 // its request/response types and the error helpers, then a per-package barrel
 // (index.ts) re-exporting each package directory's modules.
 func (g *Generator) generateModules() error {
-	moduleFiles, err := tscommon.EmitSharedModules(g.plugin)
+	moduleFiles, err := tscommon.EmitSharedModulesWithOptions(g.plugin, tscommon.GenerateOptions{
+		UseProtoFieldNames: g.useProtoFieldNames(),
+	})
 	if err != nil {
 		return err
 	}
@@ -33,7 +35,11 @@ func (g *Generator) emitClientModule(file *protogen.File) string {
 	module := file.GeneratedFilenamePrefix + "_client"
 	gf := g.plugin.NewGeneratedFile(module+".ts", "")
 	tracker := tscommon.NewImportTracker()
-	g.ctx = &tscommon.EmitContext{SelfModule: module, Imports: tracker}
+	g.ctx = &tscommon.EmitContext{
+		SelfModule:         module,
+		Imports:            tracker,
+		UseProtoFieldNames: g.useProtoFieldNames(),
+	}
 	defer func() { g.ctx = nil }()
 
 	var body []string

--- a/internal/tsclientgen/options_test.go
+++ b/internal/tsclientgen/options_test.go
@@ -1,0 +1,118 @@
+package tsclientgen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SebastienMelki/sebuf/internal/tscommon/plugintest"
+)
+
+var allMessageFixture = []string{
+	"allmessages/v1/messages.proto",
+	"allmessages/v1/service.proto",
+}
+
+func TestGenerateEmitsEveryDeclarationFromMessageOnlyCrossFile(t *testing.T) {
+	protoDir, projectRoot := tsClientTestDirs(t)
+	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture)
+
+	if err := New(plugin).Generate(); err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	content := generatedFileContent(t, plugin, "allmessages/v1/messages.ts")
+	for _, want := range []string{
+		"export interface Item {",
+		"export interface UnusedState {",
+		"export interface UnusedStateDetails {",
+		"export interface UnusedStateOrphan {",
+		"export type UnusedKind =",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("message-only module missing %q\n---\n%s", want, content)
+		}
+	}
+}
+
+func TestFieldNamesProtoCoversTypesPathAndQueryAccess(t *testing.T) {
+	protoDir, projectRoot := tsClientTestDirs(t)
+	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture)
+
+	gen := NewWithOptions(plugin, Options{FieldNames: protoFieldNames})
+	if err := gen.Generate(); err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	messages := generatedFileContent(t, plugin, "allmessages/v1/messages.ts")
+	serviceTypes := generatedFileContent(t, plugin, "allmessages/v1/service.ts")
+	client := generatedFileContent(t, plugin, "allmessages/v1/service_client.ts")
+	for _, check := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "cross-file response field", content: messages, want: "display_name: string;"},
+		{name: "unused message field", content: messages, want: "owner_id: string;"},
+		{name: "request type field", content: serviceTypes, want: "resource_id: string;"},
+		{name: "path access", content: client, want: "req.resource_id"},
+		{name: "query access", content: client, want: "req.page_size"},
+	} {
+		if !strings.Contains(check.content, check.want) {
+			t.Errorf("%s missing %q\n---\n%s", check.name, check.want, check.content)
+		}
+	}
+	for _, forbidden := range []string{"displayName: string;", "ownerId: string;", "req.resourceId", "req.pageSize"} {
+		if strings.Contains(messages+serviceTypes+client, forbidden) {
+			t.Errorf("field_names=proto output unexpectedly contains JSON-name access %q", forbidden)
+		}
+	}
+}
+
+func TestFieldNamesRejectsUnknownValue(t *testing.T) {
+	protoDir, projectRoot := tsClientTestDirs(t)
+	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture)
+
+	err := NewWithOptions(plugin, Options{FieldNames: "invalid"}).Generate()
+	if err == nil || !strings.Contains(err.Error(), "field_names must be json or proto") {
+		t.Fatalf("Generate() error = %v, want field_names validation error", err)
+	}
+}
+
+func TestFieldNamesProtoPluginOption(t *testing.T) {
+	protoDir, projectRoot := tsClientTestDirs(t)
+	pluginPath := plugintest.Build(t, projectRoot, "protoc-gen-ts-client")
+	outDir := t.TempDir()
+	args := []string{
+		"--plugin=protoc-gen-ts-client=" + pluginPath,
+		"--ts-client_out=" + outDir,
+		"--ts-client_opt=paths=source_relative,field_names=proto",
+		"--proto_path=" + protoDir,
+		"--proto_path=" + filepath.Join(projectRoot, "proto"),
+	}
+	args = append(args, allMessageFixture...)
+	cmd := exec.Command("protoc", args...)
+	cmd.Dir = protoDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("protoc failed: %v\noutput: %s", err, output)
+	}
+
+	content, err := os.ReadFile(filepath.Join(outDir, "allmessages", "v1", "service_client.ts"))
+	if err != nil {
+		t.Fatalf("read generated client: %v", err)
+	}
+	if !strings.Contains(string(content), "req.resource_id") || !strings.Contains(string(content), "req.page_size") {
+		t.Fatalf("field_names=proto plugin option was not applied:\n%s", content)
+	}
+}
+
+func tsClientTestDirs(t *testing.T) (protoDir, projectRoot string) {
+	t.Helper()
+	baseDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() failed: %v", err)
+	}
+	return filepath.Join(baseDir, "testdata", "proto"), filepath.Join(baseDir, "..", "..")
+}

--- a/internal/tsclientgen/options_test.go
+++ b/internal/tsclientgen/options_test.go
@@ -10,14 +10,16 @@ import (
 	"github.com/SebastienMelki/sebuf/internal/tscommon/plugintest"
 )
 
-var allMessageFixture = []string{
-	"allmessages/v1/messages.proto",
-	"allmessages/v1/service.proto",
+func allMessageFixture() []string {
+	return []string{
+		"allmessages/v1/messages.proto",
+		"allmessages/v1/service.proto",
+	}
 }
 
 func TestGenerateEmitsEveryDeclarationFromMessageOnlyCrossFile(t *testing.T) {
 	protoDir, projectRoot := tsClientTestDirs(t)
-	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture)
+	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture())
 
 	if err := New(plugin).Generate(); err != nil {
 		t.Fatalf("Generate() failed: %v", err)
@@ -39,7 +41,7 @@ func TestGenerateEmitsEveryDeclarationFromMessageOnlyCrossFile(t *testing.T) {
 
 func TestFieldNamesProtoCoversTypesPathAndQueryAccess(t *testing.T) {
 	protoDir, projectRoot := tsClientTestDirs(t)
-	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture)
+	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture())
 
 	gen := NewWithOptions(plugin, Options{FieldNames: protoFieldNames})
 	if err := gen.Generate(); err != nil {
@@ -73,7 +75,7 @@ func TestFieldNamesProtoCoversTypesPathAndQueryAccess(t *testing.T) {
 
 func TestFieldNamesRejectsUnknownValue(t *testing.T) {
 	protoDir, projectRoot := tsClientTestDirs(t)
-	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture)
+	plugin := buildInProcessPlugin(t, protoDir, projectRoot, allMessageFixture())
 
 	err := NewWithOptions(plugin, Options{FieldNames: "invalid"}).Generate()
 	if err == nil || !strings.Contains(err.Error(), "field_names must be json or proto") {
@@ -92,7 +94,7 @@ func TestFieldNamesProtoPluginOption(t *testing.T) {
 		"--proto_path=" + protoDir,
 		"--proto_path=" + filepath.Join(projectRoot, "proto"),
 	}
-	args = append(args, allMessageFixture...)
+	args = append(args, allMessageFixture()...)
 	cmd := exec.Command("protoc", args...)
 	cmd.Dir = protoDir
 	if output, err := cmd.CombinedOutput(); err != nil {
@@ -108,7 +110,7 @@ func TestFieldNamesProtoPluginOption(t *testing.T) {
 	}
 }
 
-func tsClientTestDirs(t *testing.T) (protoDir, projectRoot string) {
+func tsClientTestDirs(t *testing.T) (string, string) {
 	t.Helper()
 	baseDir, err := os.Getwd()
 	if err != nil {

--- a/internal/tsclientgen/testdata/golden/unwrap.ts
+++ b/internal/tsclientgen/testdata/golden/unwrap.ts
@@ -35,3 +35,33 @@ export interface RootMapWithValueUnwrapResponse {
   data: { [key: string]: OptionBar[] };
 }
 
+export interface IntList {
+  values: number[];
+}
+
+export interface ScalarMapResponse {
+  data: { [key: string]: number[] };
+}
+
+export interface RegularWrapper {
+  items: OptionBar[];
+}
+
+export interface MixedResponse {
+  unwrappedBars: { [key: string]: OptionBar[] };
+  regularBars: { [key: string]: RegularWrapper };
+  status: string;
+}
+
+export interface ScalarRootMapResponse {
+  counts: { [key: string]: number };
+}
+
+export interface ScalarRootRepeatedResponse {
+  names: string[];
+}
+
+export interface RootMapScalarListResponse {
+  groups: { [key: string]: number[] };
+}
+

--- a/internal/tsclientgen/testdata/proto/allmessages/v1/messages.proto
+++ b/internal/tsclientgen/testdata/proto/allmessages/v1/messages.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package allmessages.v1;
+
+option go_package = "github.com/SebastienMelki/sebuf/internal/tsclientgen/testdata/allmessages/v1;allmessagesv1";
+
+message Item {
+  string display_name = 1;
+}
+
+// This message is intentionally not reachable from a service method.
+message UnusedState {
+  string owner_id = 1;
+  Details details = 2;
+
+  // This nested declaration is intentionally not referenced by a field.
+  message Orphan {
+    string status_text = 1;
+  }
+
+  message Details {
+    string summary_text = 1;
+  }
+}
+
+// This enum is intentionally not reachable from a service method or field.
+enum UnusedKind {
+  UNUSED_KIND_UNSPECIFIED = 0;
+  UNUSED_KIND_ACTIVE = 1;
+}

--- a/internal/tsclientgen/testdata/proto/allmessages/v1/service.proto
+++ b/internal/tsclientgen/testdata/proto/allmessages/v1/service.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package allmessages.v1;
+
+option go_package = "github.com/SebastienMelki/sebuf/internal/tsclientgen/testdata/allmessages/v1;allmessagesv1";
+
+import "allmessages/v1/messages.proto";
+import "sebuf/http/annotations.proto";
+
+message GetItemRequest {
+  string resource_id = 1;
+  int32 page_size = 2 [(sebuf.http.query) = {name: "page_size"}];
+}
+
+service ItemService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc GetItem(GetItemRequest) returns (Item) {
+    option (sebuf.http.config) = {
+      path: "/items/{resource_id}"
+      method: HTTP_METHOD_GET
+    };
+  }
+}

--- a/internal/tscommon/imports.go
+++ b/internal/tscommon/imports.go
@@ -202,8 +202,9 @@ func (t *ImportTracker) Render(p Printer) {
 // that collects its cross-module imports. A nil context (no import tracker)
 // makes every type reference resolve to its bare name with no import recorded.
 type EmitContext struct {
-	SelfModule string // extensionless module path of the file being written
-	Imports    *ImportTracker
+	SelfModule         string // extensionless module path of the file being written
+	Imports            *ImportTracker
+	UseProtoFieldNames bool
 }
 
 func (c *EmitContext) modules() bool {

--- a/internal/tscommon/modules.go
+++ b/internal/tscommon/modules.go
@@ -32,8 +32,10 @@ func DirectPrinter(gf *protogen.GeneratedFile) Printer {
 }
 
 // CollectAllServiceMessages builds the transitive closure of every message/enum
-// referenced by any service across all generated files, plus proto-defined
-// "*Error" messages (matching CollectServiceMessages).
+// referenced by any service across all generated files. It also includes every
+// declaration in files selected for generation, so message-only files and
+// declarations that are not currently reachable from an RPC remain available
+// to consumers.
 func CollectAllServiceMessages(plugin *protogen.Plugin) *MessageSet {
 	ms := NewMessageSet()
 	for _, file := range plugin.Files {
@@ -47,9 +49,10 @@ func CollectAllServiceMessages(plugin *protogen.Plugin) *MessageSet {
 			}
 		}
 		for _, msg := range file.Messages {
-			if strings.HasSuffix(string(msg.Desc.Name()), "Error") {
-				ms.AddMessage(msg)
-			}
+			ms.AddDeclaredMessage(msg)
+		}
+		for _, enum := range file.Enums {
+			ms.AddEnum(enum)
 		}
 	}
 	return ms
@@ -94,6 +97,12 @@ func validatePathMode(plugin *protogen.Plugin) error {
 // normally, and service modules import it under a deterministic alias because
 // ImportTracker pre-reserves the helper names.
 func EmitSharedModules(plugin *protogen.Plugin) ([]string, error) {
+	return EmitSharedModulesWithOptions(plugin, GenerateOptions{})
+}
+
+// EmitSharedModulesWithOptions is EmitSharedModules with configurable
+// TypeScript declaration naming.
+func EmitSharedModulesWithOptions(plugin *protogen.Plugin, opts GenerateOptions) ([]string, error) {
 	if err := validatePathMode(plugin); err != nil {
 		return nil, err
 	}
@@ -103,7 +112,7 @@ func EmitSharedModules(plugin *protogen.Plugin) ([]string, error) {
 	enumsBySrc := global.EnumsBySourceFile()
 	var emitted []string
 	for _, src := range sortedSourceFiles(msgsBySrc, enumsBySrc) {
-		if name := emitTypeModule(plugin, src, msgsBySrc[src], enumsBySrc[src]); name != "" {
+		if name := emitTypeModule(plugin, src, msgsBySrc[src], enumsBySrc[src], opts); name != "" {
 			emitted = append(emitted, name)
 		}
 	}
@@ -178,6 +187,7 @@ func emitTypeModule(
 	srcPath string,
 	msgs []*protogen.Message,
 	enums []*protogen.Enum,
+	opts GenerateOptions,
 ) string {
 	if len(msgs) == 0 && len(enums) == 0 {
 		return ""
@@ -185,7 +195,11 @@ func emitTypeModule(
 	module := ModuleForFile(srcPath)
 	gf := plugin.NewGeneratedFile(module+".ts", "")
 	tracker := NewImportTracker()
-	ctx := &EmitContext{SelfModule: module, Imports: tracker}
+	ctx := &EmitContext{
+		SelfModule:         module,
+		Imports:            tracker,
+		UseProtoFieldNames: opts.UseProtoFieldNames,
+	}
 
 	var body []string
 	bp := BufferedPrinter(&body)

--- a/internal/tscommon/types.go
+++ b/internal/tscommon/types.go
@@ -18,6 +18,19 @@ const (
 	TSBoolean = "boolean"
 )
 
+// GenerateOptions controls the shape of emitted TypeScript declarations.
+// The zero value follows protobuf's canonical JSON mapping.
+type GenerateOptions struct {
+	UseProtoFieldNames bool
+}
+
+func fieldName(ctx *EmitContext, field *protogen.Field) string {
+	if ctx != nil && ctx.UseProtoFieldNames {
+		return string(field.Desc.Name())
+	}
+	return field.Desc.JSONName()
+}
+
 // Printer is a function that prints a formatted line.
 type Printer func(format string, args ...interface{})
 
@@ -195,6 +208,19 @@ func (ms *MessageSet) AddMessage(msg *protogen.Message) {
 		if field.Desc.Kind() == protoreflect.EnumKind && field.Enum != nil {
 			ms.AddEnum(field.Enum)
 		}
+	}
+}
+
+// AddDeclaredMessage adds a declared message and every nested declaration,
+// including nested types that are not referenced by a field. AddMessage still
+// follows field references into other files.
+func (ms *MessageSet) AddDeclaredMessage(msg *protogen.Message) {
+	ms.AddMessage(msg)
+	for _, nested := range msg.Messages {
+		ms.AddDeclaredMessage(nested)
+	}
+	for _, enum := range msg.Enums {
+		ms.AddEnum(enum)
 	}
 }
 
@@ -445,6 +471,13 @@ func GenerateInterface(p Printer, msg *protogen.Message) {
 	GenerateInterfaceCtx(nil, p, msg)
 }
 
+// GenerateInterfaceWithOptions is the configurable inline variant of
+// GenerateInterface. Module generators normally carry these options on their
+// EmitContext instead.
+func GenerateInterfaceWithOptions(p Printer, msg *protogen.Message, opts GenerateOptions) {
+	GenerateInterfaceCtx(&EmitContext{UseProtoFieldNames: opts.UseProtoFieldNames}, p, msg)
+}
+
 // GenerateInterfaceCtx is the import-aware variant of GenerateInterface. When
 // ctx is in modules mode it records cross-module type references as relative
 // imports; a nil ctx (inline mode) emits fully-qualified local names. Oneofs
@@ -529,7 +562,7 @@ func GenerateOneofDiscriminatedUnionTypeCtx(
 
 	jsonNames := make([]string, len(info.Variants))
 	for i, variant := range info.Variants {
-		jsonNames[i] = variant.Field.Desc.JSONName()
+		jsonNames[i] = fieldName(ctx, variant.Field)
 	}
 
 	var branches []string
@@ -540,7 +573,7 @@ func GenerateOneofDiscriminatedUnionTypeCtx(
 			branch = fmt.Sprintf("{ %s: \"%s\"", info.Discriminator, variant.DiscriminatorVal)
 			var sb strings.Builder
 			for _, childField := range variant.Field.Message.Fields {
-				jsonName := childField.Desc.JSONName()
+				jsonName := fieldName(ctx, childField)
 				tsType := TSFieldTypeCtx(ctx, childField)
 				fmt.Fprintf(&sb, "; %s: %s", jsonName, tsType)
 			}
@@ -575,7 +608,7 @@ func GenerateOneofDiscriminatedUnionTypeCtx(
 	fmt.Fprintf(&unset, "{ %s?: never", info.Discriminator)
 	guardedKeys := jsonNames
 	if info.Flatten {
-		guardedKeys = flattenedChildJSONNames(info)
+		guardedKeys = flattenedChildFieldNames(ctx, info)
 	}
 	for _, jsonName := range guardedKeys {
 		fmt.Fprintf(&unset, "; %s?: never", jsonName)
@@ -624,7 +657,7 @@ func nonFlattenedOneofBranch(
 // { body: "x" }) does not spuriously type-check as "nothing set". Only message
 // variants contribute keys — flatten variants are always messages, enforced by
 // validateOneofFlatten.
-func flattenedChildJSONNames(info *annotations.OneofDiscriminatorInfo) []string {
+func flattenedChildFieldNames(ctx *EmitContext, info *annotations.OneofDiscriminatorInfo) []string {
 	seen := make(map[string]bool)
 	var names []string
 	for _, variant := range info.Variants {
@@ -632,7 +665,7 @@ func flattenedChildJSONNames(info *annotations.OneofDiscriminatorInfo) []string 
 			continue
 		}
 		for _, childField := range variant.Field.Message.Fields {
-			jsonName := childField.Desc.JSONName()
+			jsonName := fieldName(ctx, childField)
 			if seen[jsonName] {
 				continue
 			}
@@ -659,7 +692,7 @@ func generatePresenceOneofUnionType(
 	jsonNames := make([]string, len(info.Variants))
 	tsTypes := make([]string, len(info.Variants))
 	for i, variant := range info.Variants {
-		jsonNames[i] = variant.Field.Desc.JSONName()
+		jsonNames[i] = fieldName(ctx, variant.Field)
 		// Route the payload through the same field-typing path normal fields
 		// use so enum variants emit the enum union (or numeric encoding) and
 		// google.protobuf.Timestamp variants emit string/number per
@@ -827,7 +860,7 @@ func GenerateFieldDeclaration(p Printer, field *protogen.Field) {
 
 // GenerateFieldDeclarationCtx is the import-aware variant.
 func GenerateFieldDeclarationCtx(ctx *EmitContext, p Printer, field *protogen.Field) {
-	jsonName := field.Desc.JSONName()
+	jsonName := fieldName(ctx, field)
 	tsType := TSFieldTypeCtx(ctx, field)
 
 	//nolint:gocritic // if-else chain is clearer than switch for distinct boolean checks
@@ -860,7 +893,7 @@ func GenerateFlattenedFields(p Printer, childMsg *protogen.Message, prefix strin
 // GenerateFlattenedFieldsCtx is the import-aware variant.
 func GenerateFlattenedFieldsCtx(ctx *EmitContext, p Printer, childMsg *protogen.Message, prefix string) {
 	for _, childField := range childMsg.Fields {
-		jsonName := prefix + childField.Desc.JSONName()
+		jsonName := prefix + fieldName(ctx, childField)
 		tsType := TSFieldTypeCtx(ctx, childField)
 
 		//nolint:gocritic // if-else chain is clearer than switch for distinct boolean checks

--- a/internal/tsservergen/testdata/golden/unwrap.ts
+++ b/internal/tsservergen/testdata/golden/unwrap.ts
@@ -35,3 +35,33 @@ export interface RootMapWithValueUnwrapResponse {
   data: { [key: string]: OptionBar[] };
 }
 
+export interface IntList {
+  values: number[];
+}
+
+export interface ScalarMapResponse {
+  data: { [key: string]: number[] };
+}
+
+export interface RegularWrapper {
+  items: OptionBar[];
+}
+
+export interface MixedResponse {
+  unwrappedBars: { [key: string]: OptionBar[] };
+  regularBars: { [key: string]: RegularWrapper };
+  status: string;
+}
+
+export interface ScalarRootMapResponse {
+  counts: { [key: string]: number };
+}
+
+export interface ScalarRootRepeatedResponse {
+  names: string[];
+}
+
+export interface RootMapScalarListResponse {
+  groups: { [key: string]: number[] };
+}
+


### PR DESCRIPTION
## Summary

This refresh rebases the remaining TypeScript work on current `main`, including
the module architecture merged in #200.

It adds:

- `field_names=json|proto` support to `protoc-gen-ts-client`
- consistent proto-name handling in generated declarations, oneofs, flattened
  fields, path substitutions, and query access
- complete per-proto modules, including declarations from message-only files
- regression fixtures for cross-file message-only protos
- aligned TS client and server goldens for the shared module collector

## Scope

This branch contains only the two TS patches. The C# generator remains isolated
in #131.

The changes intentionally extend the module layout introduced by #200 rather
than carrying the older pre-#200 implementation.

## Verification

- `go test -count=1 ./internal/tsclientgen ./internal/tsservergen`
- generated TS client/server golden comparisons passed
- generated TypeScript typechecks passed
- in-process generation tests passed
- cross-generator consistency tests passed
- focused `go vet` for `tsclientgen`, `tsservergen`, and `tscommon` passed
