### PR TITLE
chore: upgrade Go from 1.24 to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: v2.11.3
           args: ""
           only-new-issues: true
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.26'
   BUF_VERSION: 'latest'
   PROTOC_VERSION: '25.1'
 
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.24']
+        go-version: ['1.26']
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout code
@@ -168,7 +168,7 @@ jobs:
       - name: Download coverage from test job
         uses: actions/download-artifact@v8
         with:
-          name: test-results-ubuntu-latest-go1.24
+          name: test-results-ubuntu-latest-go1.26
           path: ./coverage-download
           
       - name: Verify and locate coverage file
@@ -250,7 +250,7 @@ jobs:
         uses: fgrosse/go-coverage-report@v1.3.0
         continue-on-error: true  # Don't fail on coverage reporting issues
         with:
-          coverage-artifact-name: test-results-ubuntu-latest-go1.24
+          coverage-artifact-name: test-results-ubuntu-latest-go1.26
           coverage-file-name: coverage/coverage.out
           
       - name: Upload coverage reports

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.26'
           cache: true
           
       - name: Install protoc-gen-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.26'
           cache: true
           
       - name: Setup Protoc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SebastienMelki/sebuf
 
-go 1.24.7
+go 1.26.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1

--- a/internal/httpgen/generator.go
+++ b/internal/httpgen/generator.go
@@ -912,9 +912,12 @@ func camelToSnake(s string) string {
 			if i > 0 {
 				result = append(result, '_')
 			}
-			result = append(result, byte(r+'a'-'A'))
+			result = append(
+				result,
+				byte(r-'A'+'a'),
+			) //nolint:gosec // r is guaranteed to be in [A-Z], result fits in byte
 		} else {
-			result = append(result, byte(r))
+			result = append(result, byte(r)) //nolint:gosec // input is ASCII identifier characters
 		}
 	}
 	return string(result)

--- a/internal/httpgen/generator.go
+++ b/internal/httpgen/generator.go
@@ -912,13 +912,9 @@ func camelToSnake(s string) string {
 			if i > 0 {
 				result = append(result, '_')
 			}
-			result = append(
-				result,
-				byte(r-'A'+'a'),
-			) //nolint:gosec // r is guaranteed to be in [A-Z], result fits in byte
-		} else {
-			result = append(result, byte(r)) //nolint:gosec // input is ASCII identifier characters
+			r = r - 'A' + 'a'
 		}
+		result = append(result, byte(r)) //nolint:gosec // input is ASCII identifier characters
 	}
 	return string(result)
 }


### PR DESCRIPTION
## Summary
- Upgrades Go version from 1.24 to 1.26 across all CI workflows (ci, release, proto) and `go.mod`
- Unblocks dependabot PR #142 (libopenapi 0.34.3) which requires Go >= 1.25

## Test plan
- [x] All 8 test packages pass locally
- [x] All binaries build successfully
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)