### PR TITLE
ci: add manual create-tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,65 @@
+name: Create Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (e.g. 0.10.0). Leave empty to auto-bump minor."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    name: Create Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify branch
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "::error::Tags can only be created from main. Current branch: ${{ github.ref_name }}"
+            exit 1
+          fi
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+            # Strip leading 'v' if provided
+            VERSION="${VERSION#v}"
+          else
+            # Get latest tag, strip 'v' prefix, bump minor
+            LATEST=$(git tag --sort=-v:refname | head -1)
+            LATEST="${LATEST#v}"
+            MAJOR=$(echo "$LATEST" | cut -d. -f1)
+            MINOR=$(echo "$LATEST" | cut -d. -f2)
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            MINOR=$((MINOR + 1))
+            VERSION="${MAJOR}.${MINOR}.0"
+          fi
+
+          TAG="v${VERSION}"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Summary
+        run: echo "### Created tag \`${{ steps.version.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` GitHub Action to create version tags from `main`
- Auto-bumps minor version if no version is specified (e.g. `0.9.0` → `0.10.0`)
- Guards against running from non-main branches and duplicate tags
- Created tag triggers the existing `release.yml` workflow automatically