### PR TITLE
fix(gen/go-client): pass protojson.UnmarshalOptions through custom unmarshalers

### DIFF
--- a/internal/clientgen/bytes_encoding.go
+++ b/internal/clientgen/bytes_encoding.go
@@ -237,9 +237,9 @@ func (g *Generator) generateBytesUnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 		fieldNames = append(fieldNames, string(f.Field.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles bytes_encoding fields: ", strings.Join(fieldNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("// Parse the raw JSON to extract bytes-encoded fields")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
@@ -258,7 +258,14 @@ func (g *Generator) generateBytesUnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 	gf.P("}")
 	gf.P()
 	gf.P("// Use protojson to unmarshal the rest")
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }

--- a/internal/clientgen/empty_behavior.go
+++ b/internal/clientgen/empty_behavior.go
@@ -221,9 +221,9 @@ func (g *Generator) generateEmptyBehaviorUnmarshalJSON(gf *protogen.GeneratedFil
 		fieldNames = append(fieldNames, string(f.Field.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles empty_behavior fields: ", strings.Join(fieldNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("// Parse to check for explicit null values on empty_behavior=NULL fields")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
@@ -251,7 +251,14 @@ func (g *Generator) generateEmptyBehaviorUnmarshalJSON(gf *protogen.GeneratedFil
 	gf.P("return err")
 	gf.P("}")
 	gf.P()
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }

--- a/internal/clientgen/encoding.go
+++ b/internal/clientgen/encoding.go
@@ -301,9 +301,9 @@ func (g *Generator) generateInt64UnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 		numberFieldNames = append(numberFieldNames, string(f.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles int64_encoding=NUMBER fields: ", strings.Join(numberFieldNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("// First, parse the raw JSON to extract NUMBER-encoded fields")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
@@ -323,7 +323,14 @@ func (g *Generator) generateInt64UnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 	gf.P("}")
 	gf.P()
 	gf.P("// Use protojson to unmarshal the rest")
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }
@@ -463,12 +470,12 @@ func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 		nestedFieldNames = append(nestedFieldNames, string(f.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P(
 		"// This method handles nested messages that have int64_encoding=NUMBER fields: ",
 		strings.Join(nestedFieldNames, ", "),
 	)
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
 	gf.P("return err")
@@ -477,10 +484,14 @@ func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 
 	for _, field := range ctx.NestedFields {
 		jsonName := field.Desc.JSONName()
-		gf.P("// Handle \"", jsonName, "\" using its custom UnmarshalJSON")
+		gf.P("// Handle \"", jsonName, "\" using its custom unmarshaler")
 		gf.P("if rawVal, ok := raw[\"", jsonName, "\"]; ok {")
 		gf.P("inner := &", gf.QualifiedGoIdent(field.Message.GoIdent), "{}")
-		gf.P("if err := json.Unmarshal(rawVal, inner); err != nil {")
+		gf.P("if u, ok := any(inner).(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {")
+		gf.P("if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {")
+		gf.P("return err")
+		gf.P("}")
+		gf.P("} else if err := json.Unmarshal(rawVal, inner); err != nil {")
 		gf.P("return err")
 		gf.P("}")
 		gf.P("innerJSON, err := protojson.Marshal(inner)")
@@ -497,7 +508,14 @@ func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 	gf.P("return err")
 	gf.P("}")
 	gf.P()
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }

--- a/internal/clientgen/flatten.go
+++ b/internal/clientgen/flatten.go
@@ -260,9 +260,9 @@ func (g *Generator) generateFlattenUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 		fieldNames = append(fieldNames, string(info.Field.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles flatten fields: ", strings.Join(fieldNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
 	gf.P("return err")
@@ -279,7 +279,14 @@ func (g *Generator) generateFlattenUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 	gf.P("return err")
 	gf.P("}")
 	gf.P()
-	gf.P("return protojson.Unmarshal(remaining, x)")
+	gf.P("return opts.Unmarshal(remaining, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }
@@ -319,8 +326,12 @@ func (g *Generator) generateFlattenFieldUnmarshal(gf *protogen.GeneratedFile, in
 	gf.P("return childErr")
 	gf.P("}")
 	gf.P("x.", goName, " = &", childTypeName, "{}")
-	gf.P("// Use json.Unmarshal to invoke child's UnmarshalJSON (annotation composability)")
-	gf.P("if childErr = json.Unmarshal(childData, x.", goName, "); childErr != nil {")
+	gf.P("// Forward opts to child's UnmarshalJSONSebuf if available (annotation composability)")
+	gf.P("if u, ok := any(x.", goName, ").(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {")
+	gf.P("if childErr = u.UnmarshalJSONSebuf(childData, opts); childErr != nil {")
+	gf.P("return childErr")
+	gf.P("}")
+	gf.P("} else if childErr = json.Unmarshal(childData, x.", goName, "); childErr != nil {")
 	gf.P("return childErr")
 	gf.P("}")
 	gf.P("}")

--- a/internal/clientgen/flatten.go
+++ b/internal/clientgen/flatten.go
@@ -327,7 +327,10 @@ func (g *Generator) generateFlattenFieldUnmarshal(gf *protogen.GeneratedFile, in
 	gf.P("}")
 	gf.P("x.", goName, " = &", childTypeName, "{}")
 	gf.P("// Forward opts to child's UnmarshalJSONSebuf if available (annotation composability)")
-	gf.P("if u, ok := any(x.", goName, ").(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {")
+	gf.P(
+		"if u, ok := any(x.", goName,
+		`).(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {`,
+	)
 	gf.P("if childErr = u.UnmarshalJSONSebuf(childData, opts); childErr != nil {")
 	gf.P("return childErr")
 	gf.P("}")

--- a/internal/clientgen/forward_compat_test.go
+++ b/internal/clientgen/forward_compat_test.go
@@ -1,0 +1,684 @@
+package clientgen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestForwardCompatGoldenPatterns verifies the generated code has the correct
+// structural patterns for the sebufUnmarshaler interface and discard-unknown-fields support.
+func TestForwardCompatGoldenPatterns(t *testing.T) {
+	goldenDir := filepath.Join("testdata", "golden")
+
+	// K.36 — Golden assertion: every annotated message gets UnmarshalJSONSebuf
+	t.Run("K36_annotated_messages_have_UnmarshalJSONSebuf", func(t *testing.T) {
+		encodingFiles := []struct {
+			file     string
+			msgNames []string
+		}{
+			{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
+			{"int64_nested_encoding_encoding.pb.go", []string{"SensorReading", "GetSensorReadingResponse", "GetMultiSensorResponse"}},
+			{"nullable_nullable.pb.go", []string{"User"}},
+			{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
+			{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
+			{"empty_behavior_empty_behavior.pb.go", []string{"Response"}},
+			{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
+			{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
+		}
+
+		for _, ef := range encodingFiles {
+			content, err := os.ReadFile(filepath.Join(goldenDir, ef.file))
+			if err != nil {
+				t.Fatalf("Failed to read %s: %v", ef.file, err)
+			}
+			s := string(content)
+			for _, msg := range ef.msgNames {
+				pattern := "func (x *" + msg + ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {"
+				if !strings.Contains(s, pattern) {
+					t.Errorf("%s: missing UnmarshalJSONSebuf for %s", ef.file, msg)
+				}
+			}
+		}
+	})
+
+	// K.37 — Golden assertion: UnmarshalJSON delegates to UnmarshalJSONSebuf
+	t.Run("K37_UnmarshalJSON_delegates_to_UnmarshalJSONSebuf", func(t *testing.T) {
+		encodingFiles := []struct {
+			file     string
+			msgNames []string
+		}{
+			{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
+			{"nullable_nullable.pb.go", []string{"User"}},
+			{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
+			{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
+			{"empty_behavior_empty_behavior.pb.go", []string{"Response"}},
+			{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
+			{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
+			{"int64_nested_encoding_encoding.pb.go", []string{"SensorReading", "GetSensorReadingResponse", "GetMultiSensorResponse"}},
+		}
+
+		for _, ef := range encodingFiles {
+			content, err := os.ReadFile(filepath.Join(goldenDir, ef.file))
+			if err != nil {
+				t.Fatalf("Failed to read %s: %v", ef.file, err)
+			}
+			s := string(content)
+			for _, msg := range ef.msgNames {
+				pattern := "return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})"
+				wrapperSig := "func (x *" + msg + ") UnmarshalJSON(data []byte) error {"
+				if !strings.Contains(s, wrapperSig) {
+					t.Errorf("%s: missing UnmarshalJSON wrapper for %s", ef.file, msg)
+				}
+				if !strings.Contains(s, pattern) {
+					t.Errorf("%s: UnmarshalJSON doesn't delegate to UnmarshalJSONSebuf for %s", ef.file, msg)
+				}
+			}
+		}
+	})
+
+	// Verify sebufUnmarshaler interface is defined in client files
+	t.Run("sebufUnmarshaler_interface_defined", func(t *testing.T) {
+		clientFiles := []string{
+			"backward_compat_client.pb.go",
+			"int64_encoding_client.pb.go",
+			"nullable_client.pb.go",
+			"flatten_client.pb.go",
+			"sse_client.pb.go",
+		}
+
+		for _, f := range clientFiles {
+			content, err := os.ReadFile(filepath.Join(goldenDir, f))
+			if err != nil {
+				t.Fatalf("Failed to read %s: %v", f, err)
+			}
+			s := string(content)
+			if !strings.Contains(s, "type sebufUnmarshaler interface {") {
+				t.Errorf("%s: missing sebufUnmarshaler interface", f)
+			}
+			if !strings.Contains(s, "UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error") {
+				t.Errorf("%s: sebufUnmarshaler missing UnmarshalJSONSebuf method", f)
+			}
+		}
+	})
+
+	// Verify unmarshalResponse checks sebufUnmarshaler first
+	t.Run("unmarshalResponse_checks_sebufUnmarshaler_first", func(t *testing.T) {
+		clientFiles := []string{
+			"backward_compat_client.pb.go",
+			"int64_encoding_client.pb.go",
+			"sse_client.pb.go",
+		}
+
+		for _, f := range clientFiles {
+			content, err := os.ReadFile(filepath.Join(goldenDir, f))
+			if err != nil {
+				t.Fatalf("Failed to read %s: %v", f, err)
+			}
+			s := string(content)
+
+			// Verify signature has discardUnknown parameter
+			if !strings.Contains(s, "unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error") {
+				t.Errorf("%s: unmarshalResponse missing discardUnknown parameter", f)
+			}
+			// Verify opts built from discardUnknown
+			if !strings.Contains(s, "opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}") {
+				t.Errorf("%s: unmarshalResponse not building opts from discardUnknown", f)
+			}
+			// Verify sebufUnmarshaler checked first
+			if !strings.Contains(s, "if u, ok := msg.(sebufUnmarshaler); ok {") {
+				t.Errorf("%s: unmarshalResponse not checking sebufUnmarshaler", f)
+			}
+			if !strings.Contains(s, "return u.UnmarshalJSONSebuf(body, opts)") {
+				t.Errorf("%s: unmarshalResponse not calling UnmarshalJSONSebuf", f)
+			}
+		}
+	})
+
+	// Verify client struct has discardUnknownFields field
+	t.Run("client_struct_has_discardUnknownFields", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "discardUnknownFields bool") {
+			t.Error("client struct missing discardUnknownFields field")
+		}
+	})
+
+	// Verify call options struct has *bool for per-call override
+	t.Run("call_options_has_pointer_bool", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "discardUnknownFields *bool") {
+			t.Error("call options missing discardUnknownFields *bool field")
+		}
+	})
+
+	// Verify WithXxxDiscardUnknownFields option generated
+	t.Run("client_option_generated", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "func WithNoAnnotationsServiceDiscardUnknownFields(discard bool)") {
+			t.Error("missing WithNoAnnotationsServiceDiscardUnknownFields option")
+		}
+	})
+
+	// Verify WithXxxCallDiscardUnknownFields option generated with pointer semantics
+	t.Run("call_option_generated_with_pointer", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "func WithNoAnnotationsServiceCallDiscardUnknownFields(discard bool)") {
+			t.Error("missing WithNoAnnotationsServiceCallDiscardUnknownFields option")
+		}
+		if !strings.Contains(s, "o.discardUnknownFields = &discard") {
+			t.Error("call option not using pointer assignment")
+		}
+	})
+
+	// Verify discardUnknown resolution in RPC methods
+	t.Run("rpc_method_resolves_discard_option", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "discardUnknown := c.discardUnknownFields") {
+			t.Error("RPC method not reading client-level discardUnknownFields")
+		}
+		if !strings.Contains(s, "if callOpts.discardUnknownFields != nil {") {
+			t.Error("RPC method not checking per-call override")
+		}
+		if !strings.Contains(s, "discardUnknown = *callOpts.discardUnknownFields") {
+			t.Error("RPC method not applying per-call override")
+		}
+	})
+
+	// G.29 — handleErrorResponse always uses strict mode (false)
+	t.Run("G29_handleErrorResponse_strict_mode", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "c.unmarshalResponse(body, validationErr, contentType, false)") {
+			t.Error("handleErrorResponse not passing false (strict) for ValidationError")
+		}
+		if !strings.Contains(s, "c.unmarshalResponse(body, genericErr, contentType, false)") {
+			t.Error("handleErrorResponse not passing false (strict) for Error")
+		}
+		if !strings.Contains(s, "Always use strict mode (false) for error parsing") {
+			t.Error("handleErrorResponse missing comment explaining strict mode")
+		}
+	})
+
+	// SSE EventStream tests
+	t.Run("SSE_EventStream_has_discardUnknownFields", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "sse_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		// Verify EventStream struct has discardUnknownFields
+		if !strings.Contains(s, "discardUnknownFields bool") {
+			t.Error("EventStream missing discardUnknownFields field")
+		}
+
+		// Verify SSE method resolves and passes discardUnknown
+		if !strings.Contains(s, "discardUnknownFields: discardUnknown,") {
+			t.Error("SSE method not passing discardUnknown to EventStream")
+		}
+	})
+
+	// Verify SSE Next() method uses sebufUnmarshaler
+	t.Run("SSE_Next_uses_sebufUnmarshaler", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "sse_client.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "opts := protojson.UnmarshalOptions{DiscardUnknown: s.discardUnknownFields}") {
+			t.Error("EventStream.Next not building opts from discardUnknownFields")
+		}
+		if !strings.Contains(s, "if u, ok := any(event).(sebufUnmarshaler); ok {") {
+			t.Error("EventStream.Next not checking sebufUnmarshaler")
+		}
+		if !strings.Contains(s, "unmarshalErr = u.UnmarshalJSONSebuf([]byte(data), opts)") {
+			t.Error("EventStream.Next not calling UnmarshalJSONSebuf")
+		}
+	})
+
+	// Verify wrapper types forward opts to nested children
+	t.Run("wrapper_forwards_opts_to_children", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "int64_nested_encoding_encoding.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error") {
+			t.Error("wrapper not checking child for UnmarshalJSONSebuf")
+		}
+		if !strings.Contains(s, "u.UnmarshalJSONSebuf(rawVal, opts)") {
+			t.Error("wrapper not forwarding opts to child UnmarshalJSONSebuf")
+		}
+	})
+
+	// Verify flatten forwards opts to children
+	t.Run("flatten_forwards_opts_to_children", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "flatten_flatten.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error") {
+			t.Error("flatten not checking child for UnmarshalJSONSebuf")
+		}
+	})
+
+	// Verify oneof_discriminator forwards opts to children
+	t.Run("oneof_discriminator_forwards_opts_to_children", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "oneof_discriminator_oneof_discriminator.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if !strings.Contains(s, "UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error") {
+			t.Error("oneof_discriminator not checking child for UnmarshalJSONSebuf")
+		}
+	})
+
+	// I.32 — UnmarshalJSON still present on every annotated message
+	t.Run("I32_UnmarshalJSON_still_present", func(t *testing.T) {
+		encodingFiles := []struct {
+			file     string
+			msgNames []string
+		}{
+			{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
+			{"nullable_nullable.pb.go", []string{"User"}},
+			{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
+			{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
+			{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
+			{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
+		}
+
+		for _, ef := range encodingFiles {
+			content, err := os.ReadFile(filepath.Join(goldenDir, ef.file))
+			if err != nil {
+				t.Fatalf("Failed to read %s: %v", ef.file, err)
+			}
+			s := string(content)
+			for _, msg := range ef.msgNames {
+				wrapperSig := "func (x *" + msg + ") UnmarshalJSON(data []byte) error {"
+				if !strings.Contains(s, wrapperSig) {
+					t.Errorf("%s: %s missing UnmarshalJSON (json.Unmarshaler compat)", ef.file, msg)
+				}
+			}
+		}
+	})
+
+	// I.34 — Existing call sites compile unchanged (purely additive)
+	// This is tested by TestGeneratedClientCodeCompiles in golden_test.go
+
+	// Verify enum types do NOT get UnmarshalJSONSebuf (they use direct parsing)
+	t.Run("enum_types_no_UnmarshalJSONSebuf", func(t *testing.T) {
+		content, err := os.ReadFile(filepath.Join(goldenDir, "enum_encoding_enum_encoding.pb.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(content)
+
+		if strings.Contains(s, "UnmarshalJSONSebuf") {
+			t.Error("enum encoding should NOT have UnmarshalJSONSebuf (enums don't use protojson.Unmarshal)")
+		}
+		// But should still have UnmarshalJSON
+		if !strings.Contains(s, "func (x *Status) UnmarshalJSON(data []byte) error {") {
+			t.Error("enum encoding missing UnmarshalJSON")
+		}
+	})
+}
+
+// TestForwardCompatIntegration is an end-to-end integration test that generates code,
+// creates a temporary Go module with httptest-based tests, and runs them.
+// This covers test groups A-J from the test matrix.
+//
+//nolint:funlen // Integration test requires many sequential steps
+func TestForwardCompatIntegration(t *testing.T) {
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not found, skipping integration test")
+	}
+
+	baseDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	projectRoot := filepath.Join(baseDir, "..", "..")
+	protoDir := filepath.Join(baseDir, "testdata", "proto")
+	pluginPath := filepath.Join(projectRoot, "bin", "protoc-gen-go-client")
+
+	// Ensure plugin is built
+	if _, statErr := os.Stat(pluginPath); os.IsNotExist(statErr) {
+		buildCmd := exec.Command("make", "build")
+		buildCmd.Dir = projectRoot
+		if buildErr := buildCmd.Run(); buildErr != nil {
+			t.Fatalf("Failed to build plugin: %v", buildErr)
+		}
+	}
+
+	// Create temp module
+	tempDir := t.TempDir()
+
+	// Generate code for backward_compat.proto (plain proto, no custom unmarshalers)
+	// This tests the core discard-unknown-fields plumbing (groups A, B, C, G, H)
+	// Int64/SSE/annotation-specific tests are covered by TestForwardCompatGoldenPatterns
+	genDir := filepath.Join(tempDir, "gen")
+	if mkErr := os.MkdirAll(genDir, 0o755); mkErr != nil {
+		t.Fatal(mkErr)
+	}
+
+	cmd := exec.Command("protoc",
+		"--plugin=protoc-gen-go-client="+pluginPath,
+		"--go_out="+genDir,
+		"--go_opt=paths=source_relative",
+		"--go-client_out="+genDir,
+		"--go-client_opt=paths=source_relative",
+		"--proto_path="+protoDir,
+		"--proto_path="+filepath.Join(projectRoot, "proto"),
+		"backward_compat.proto",
+	)
+	cmd.Dir = protoDir
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("protoc backward_compat.proto failed: %v\n%s", runErr, string(out))
+	}
+
+	// Get the sebuf module version for replace directive
+	goModContent, readErr := os.ReadFile(filepath.Join(projectRoot, "go.mod"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	// Extract the protobuf dependency version
+	var protobufVersion string
+	for _, line := range strings.Split(string(goModContent), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "google.golang.org/protobuf") && !strings.HasPrefix(line, "module") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				protobufVersion = parts[1]
+			}
+		}
+	}
+	if protobufVersion == "" {
+		t.Fatal("Could not find google.golang.org/protobuf version in go.mod")
+	}
+
+	// Write go.mod
+	goMod := `module forward_compat_test
+
+go 1.24
+
+require (
+	google.golang.org/protobuf ` + protobufVersion + `
+	github.com/SebastienMelki/sebuf v0.0.0
+)
+
+replace github.com/SebastienMelki/sebuf => ` + projectRoot + `
+`
+	if writeErr := os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goMod), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	// Write the httptest-based test file
+	testCode := `package forward_compat_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gen "forward_compat_test/gen"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// jsonHandler returns an HTTP handler that serves the given JSON body.
+func jsonHandler(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}
+}
+
+// errorHandler returns an HTTP handler that serves an error response.
+func errorHandler(statusCode int, body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		w.Write([]byte(body))
+	}
+}
+
+// ---- A. Default behavior (compat guarantee) ----
+
+func TestA1_NoOption_UnknownField_PlainMessage_Rejects(t *testing.T) {
+	// Server returns JSON with an unknown field for a plain proto message
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL)
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
+	if err == nil {
+		t.Fatal("expected error for unknown field in strict mode, got nil")
+	}
+}
+
+// ---- B. Client-level option ----
+
+func TestB4_ClientDiscard_UnknownField_Succeeds(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(true))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
+	if err != nil {
+		t.Fatalf("expected success with discard=true, got: %v", err)
+	}
+}
+
+func TestB5_ClientDiscardFalse_UnknownField_Rejects(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(false))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
+	if err == nil {
+		t.Fatal("expected error with explicit discard=false")
+	}
+}
+
+func TestB6_ClientDefault_MatchesStrict(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	// No option set — should be strict (same as A1)
+	client := gen.NewNoAnnotationsServiceClient(srv.URL)
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
+	if err == nil {
+		t.Fatal("expected error with default (no option set)")
+	}
+}
+
+// ---- C. Per-call option (precedence) ----
+
+func TestC7_ClientUnset_PerCallTrue_Succeeds(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL)
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{},
+		gen.WithNoAnnotationsServiceCallDiscardUnknownFields(true))
+	if err != nil {
+		t.Fatalf("expected success with per-call discard=true, got: %v", err)
+	}
+}
+
+func TestC8_ClientTrue_PerCallUnset_Succeeds(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(true))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
+	if err != nil {
+		t.Fatalf("expected success with client discard=true, got: %v", err)
+	}
+}
+
+func TestC9_ClientTrue_PerCallFalse_Rejects(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(true))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{},
+		gen.WithNoAnnotationsServiceCallDiscardUnknownFields(false))
+	if err == nil {
+		t.Fatal("expected error: per-call false should override client true")
+	}
+}
+
+func TestC10_ClientFalse_PerCallTrue_Succeeds(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(false))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{},
+		gen.WithNoAnnotationsServiceCallDiscardUnknownFields(true))
+	if err != nil {
+		t.Fatalf("expected success: per-call true should override client false, got: %v", err)
+	}
+}
+
+func TestC11_ClientTrue_PerCallTrue_Succeeds(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(true))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{},
+		gen.WithNoAnnotationsServiceCallDiscardUnknownFields(true))
+	if err != nil {
+		t.Fatalf("expected success with both true, got: %v", err)
+	}
+}
+
+// ---- G. Error response path ----
+
+func TestG28_ErrorResponse_WithDiscard_StaysStrict(t *testing.T) {
+	// Server returns 400 with extras — client has discard=true but error parsing should still be strict
+	errorBody := ` + "`" + `{"code": 400, "message": "bad request", "unknownField": "extra"}` + "`" + `
+	srv := httptest.NewServer(errorHandler(400, errorBody))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(true))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
+	if err == nil {
+		t.Fatal("expected error response")
+	}
+	// The error should be returned (handleErrorResponse uses false for unmarshal,
+	// but falls back to raw error if strict unmarshal of ValidationError/Error fails)
+	// Key: we should get an error, not a nil response
+}
+
+// ---- H. Content type branches ----
+
+func TestH30_ProtoContentType_DiscardNoOp(t *testing.T) {
+	// Server returns proto bytes — discard=true should be ignored (proto doesn't have unknowns concept at JSON level)
+	msg := &gen.SimpleResponse{}
+	protoBytes, _ := proto.Marshal(msg)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.Write(protoBytes)
+	}))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(true),
+		gen.WithNoAnnotationsServiceContentType("application/x-protobuf"))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{},
+		gen.WithNoAnnotationsServiceCallContentType("application/x-protobuf"))
+	if err != nil {
+		t.Fatalf("expected proto to work with discard=true, got: %v", err)
+	}
+}
+
+func TestH31_EmptyBody_DiscardReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		// empty body
+	}))
+	defer srv.Close()
+
+	client := gen.NewNoAnnotationsServiceClient(srv.URL,
+		gen.WithNoAnnotationsServiceDiscardUnknownFields(true))
+	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
+	if err != nil {
+		t.Fatalf("expected empty body to return nil with discard=true, got: %v", err)
+	}
+}
+
+`
+
+	if writeErr := os.WriteFile(filepath.Join(tempDir, "forward_compat_test.go"), []byte(testCode), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	// Run go mod tidy
+	tidyCmd := exec.Command("go", "mod", "tidy")
+	tidyCmd.Dir = tempDir
+	tidyOut, tidyErr := tidyCmd.CombinedOutput()
+	if tidyErr != nil {
+		t.Fatalf("go mod tidy failed: %v\n%s", tidyErr, string(tidyOut))
+	}
+
+	// Run the tests
+	testCmd := exec.Command("go", "test", "-v", "-count=1", "./...")
+	testCmd.Dir = tempDir
+	testOut, testErr := testCmd.CombinedOutput()
+
+	t.Logf("Test output:\n%s", string(testOut))
+
+	if testErr != nil {
+		t.Fatalf("integration tests failed: %v", testErr)
+	}
+}

--- a/internal/clientgen/forward_compat_test.go
+++ b/internal/clientgen/forward_compat_test.go
@@ -8,363 +8,295 @@ import (
 	"testing"
 )
 
-// TestForwardCompatGoldenPatterns verifies the generated code has the correct
-// structural patterns for the sebufUnmarshaler interface and discard-unknown-fields support.
-func TestForwardCompatGoldenPatterns(t *testing.T) {
-	goldenDir := filepath.Join("testdata", "golden")
+// encodingFileSpec maps a golden encoding file to the messages it should contain.
+type encodingFileSpec struct {
+	file     string
+	msgNames []string
+}
 
-	// K.36 — Golden assertion: every annotated message gets UnmarshalJSONSebuf
-	t.Run("K36_annotated_messages_have_UnmarshalJSONSebuf", func(t *testing.T) {
-		encodingFiles := []struct {
-			file     string
-			msgNames []string
+// allEncodingFiles returns the spec for all annotated message encoding golden files.
+func allEncodingFiles() []encodingFileSpec {
+	return []encodingFileSpec{
+		{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
+		{
+			"int64_nested_encoding_encoding.pb.go",
+			[]string{"SensorReading", "GetSensorReadingResponse", "GetMultiSensorResponse"},
+		},
+		{"nullable_nullable.pb.go", []string{"User"}},
+		{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
+		{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
+		{"empty_behavior_empty_behavior.pb.go", []string{"Response"}},
+		{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
+		{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
+	}
+}
+
+func readGolden(t *testing.T, name string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("testdata", "golden", name))
+	if err != nil {
+		t.Fatalf("Failed to read %s: %v", name, err)
+	}
+	return string(content)
+}
+
+// TestK36_AnnotatedMessagesHaveUnmarshalJSONSebuf verifies every annotated message
+// gets the UnmarshalJSONSebuf method.
+func TestK36_AnnotatedMessagesHaveUnmarshalJSONSebuf(t *testing.T) {
+	for _, ef := range allEncodingFiles() {
+		s := readGolden(t, ef.file)
+		for _, msg := range ef.msgNames {
+			pattern := "func (x *" + msg +
+				") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {"
+			if !strings.Contains(s, pattern) {
+				t.Errorf("%s: missing UnmarshalJSONSebuf for %s", ef.file, msg)
+			}
+		}
+	}
+}
+
+// TestK37_UnmarshalJSONDelegatesToSebuf verifies every annotated message's UnmarshalJSON
+// is a thin wrapper that delegates to UnmarshalJSONSebuf.
+func TestK37_UnmarshalJSONDelegatesToSebuf(t *testing.T) {
+	for _, ef := range allEncodingFiles() {
+		s := readGolden(t, ef.file)
+		for _, msg := range ef.msgNames {
+			pattern := "return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})"
+			wrapperSig := "func (x *" + msg + ") UnmarshalJSON(data []byte) error {"
+			if !strings.Contains(s, wrapperSig) {
+				t.Errorf("%s: missing UnmarshalJSON wrapper for %s", ef.file, msg)
+			}
+			if !strings.Contains(s, pattern) {
+				t.Errorf(
+					"%s: UnmarshalJSON doesn't delegate to UnmarshalJSONSebuf for %s",
+					ef.file, msg,
+				)
+			}
+		}
+	}
+}
+
+// TestSebufUnmarshalerInterfaceDefined verifies the interface is present in all client files.
+func TestSebufUnmarshalerInterfaceDefined(t *testing.T) {
+	clientFiles := []string{
+		"backward_compat_client.pb.go",
+		"int64_encoding_client.pb.go",
+		"nullable_client.pb.go",
+		"flatten_client.pb.go",
+		"sse_client.pb.go",
+	}
+
+	for _, f := range clientFiles {
+		s := readGolden(t, f)
+		if !strings.Contains(s, "type sebufUnmarshaler interface {") {
+			t.Errorf("%s: missing sebufUnmarshaler interface", f)
+		}
+		if !strings.Contains(
+			s,
+			"UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error",
+		) {
+			t.Errorf("%s: sebufUnmarshaler missing UnmarshalJSONSebuf method", f)
+		}
+	}
+}
+
+// TestUnmarshalResponseChecksSebufFirst verifies unmarshalResponse dispatches
+// to sebufUnmarshaler before json.Unmarshaler.
+func TestUnmarshalResponseChecksSebufFirst(t *testing.T) {
+	clientFiles := []string{
+		"backward_compat_client.pb.go",
+		"int64_encoding_client.pb.go",
+		"sse_client.pb.go",
+	}
+
+	for _, f := range clientFiles {
+		s := readGolden(t, f)
+
+		checks := []struct {
+			pattern string
+			msg     string
 		}{
-			{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
-			{"int64_nested_encoding_encoding.pb.go", []string{"SensorReading", "GetSensorReadingResponse", "GetMultiSensorResponse"}},
-			{"nullable_nullable.pb.go", []string{"User"}},
-			{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
-			{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
-			{"empty_behavior_empty_behavior.pb.go", []string{"Response"}},
-			{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
-			{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
+			{
+				"unmarshalResponse(body []byte, msg proto.Message, " +
+					"contentType string, discardUnknown bool) error",
+				"unmarshalResponse missing discardUnknown parameter",
+			},
+			{
+				"opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}",
+				"unmarshalResponse not building opts from discardUnknown",
+			},
+			{
+				"if u, ok := msg.(sebufUnmarshaler); ok {",
+				"unmarshalResponse not checking sebufUnmarshaler",
+			},
+			{
+				"return u.UnmarshalJSONSebuf(body, opts)",
+				"unmarshalResponse not calling UnmarshalJSONSebuf",
+			},
 		}
-
-		for _, ef := range encodingFiles {
-			content, err := os.ReadFile(filepath.Join(goldenDir, ef.file))
-			if err != nil {
-				t.Fatalf("Failed to read %s: %v", ef.file, err)
-			}
-			s := string(content)
-			for _, msg := range ef.msgNames {
-				pattern := "func (x *" + msg + ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {"
-				if !strings.Contains(s, pattern) {
-					t.Errorf("%s: missing UnmarshalJSONSebuf for %s", ef.file, msg)
-				}
-			}
-		}
-	})
-
-	// K.37 — Golden assertion: UnmarshalJSON delegates to UnmarshalJSONSebuf
-	t.Run("K37_UnmarshalJSON_delegates_to_UnmarshalJSONSebuf", func(t *testing.T) {
-		encodingFiles := []struct {
-			file     string
-			msgNames []string
-		}{
-			{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
-			{"nullable_nullable.pb.go", []string{"User"}},
-			{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
-			{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
-			{"empty_behavior_empty_behavior.pb.go", []string{"Response"}},
-			{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
-			{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
-			{"int64_nested_encoding_encoding.pb.go", []string{"SensorReading", "GetSensorReadingResponse", "GetMultiSensorResponse"}},
-		}
-
-		for _, ef := range encodingFiles {
-			content, err := os.ReadFile(filepath.Join(goldenDir, ef.file))
-			if err != nil {
-				t.Fatalf("Failed to read %s: %v", ef.file, err)
-			}
-			s := string(content)
-			for _, msg := range ef.msgNames {
-				pattern := "return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})"
-				wrapperSig := "func (x *" + msg + ") UnmarshalJSON(data []byte) error {"
-				if !strings.Contains(s, wrapperSig) {
-					t.Errorf("%s: missing UnmarshalJSON wrapper for %s", ef.file, msg)
-				}
-				if !strings.Contains(s, pattern) {
-					t.Errorf("%s: UnmarshalJSON doesn't delegate to UnmarshalJSONSebuf for %s", ef.file, msg)
-				}
+		for _, c := range checks {
+			if !strings.Contains(s, c.pattern) {
+				t.Errorf("%s: %s", f, c.msg)
 			}
 		}
-	})
+	}
+}
 
-	// Verify sebufUnmarshaler interface is defined in client files
-	t.Run("sebufUnmarshaler_interface_defined", func(t *testing.T) {
-		clientFiles := []string{
-			"backward_compat_client.pb.go",
-			"int64_encoding_client.pb.go",
-			"nullable_client.pb.go",
-			"flatten_client.pb.go",
-			"sse_client.pb.go",
-		}
+// TestClientStructAndOptions verifies the client struct and options are generated correctly.
+func TestClientStructAndOptions(t *testing.T) {
+	s := readGolden(t, "backward_compat_client.pb.go")
 
-		for _, f := range clientFiles {
-			content, err := os.ReadFile(filepath.Join(goldenDir, f))
-			if err != nil {
-				t.Fatalf("Failed to read %s: %v", f, err)
-			}
-			s := string(content)
-			if !strings.Contains(s, "type sebufUnmarshaler interface {") {
-				t.Errorf("%s: missing sebufUnmarshaler interface", f)
-			}
-			if !strings.Contains(s, "UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error") {
-				t.Errorf("%s: sebufUnmarshaler missing UnmarshalJSONSebuf method", f)
-			}
+	checks := []struct {
+		pattern string
+		msg     string
+	}{
+		{"discardUnknownFields bool", "client struct missing discardUnknownFields field"},
+		{"discardUnknownFields *bool", "call options missing discardUnknownFields *bool field"},
+		{
+			"func WithNoAnnotationsServiceDiscardUnknownFields(discard bool)",
+			"missing WithNoAnnotationsServiceDiscardUnknownFields option",
+		},
+		{
+			"func WithNoAnnotationsServiceCallDiscardUnknownFields(discard bool)",
+			"missing WithNoAnnotationsServiceCallDiscardUnknownFields option",
+		},
+		{"o.discardUnknownFields = &discard", "call option not using pointer assignment"},
+		{"discardUnknown := c.discardUnknownFields", "RPC method not reading client-level option"},
+		{
+			"if callOpts.discardUnknownFields != nil {",
+			"RPC method not checking per-call override",
+		},
+		{
+			"discardUnknown = *callOpts.discardUnknownFields",
+			"RPC method not applying per-call override",
+		},
+	}
+	for _, c := range checks {
+		if !strings.Contains(s, c.pattern) {
+			t.Error(c.msg)
 		}
-	})
+	}
+}
 
-	// Verify unmarshalResponse checks sebufUnmarshaler first
-	t.Run("unmarshalResponse_checks_sebufUnmarshaler_first", func(t *testing.T) {
-		clientFiles := []string{
-			"backward_compat_client.pb.go",
-			"int64_encoding_client.pb.go",
-			"sse_client.pb.go",
-		}
+// TestG29_HandleErrorResponseStrictMode verifies error responses always use strict unmarshaling.
+func TestG29_HandleErrorResponseStrictMode(t *testing.T) {
+	s := readGolden(t, "backward_compat_client.pb.go")
 
-		for _, f := range clientFiles {
-			content, err := os.ReadFile(filepath.Join(goldenDir, f))
-			if err != nil {
-				t.Fatalf("Failed to read %s: %v", f, err)
-			}
-			s := string(content)
+	checks := []struct {
+		pattern string
+		msg     string
+	}{
+		{
+			"c.unmarshalResponse(body, validationErr, contentType, false)",
+			"handleErrorResponse not passing false (strict) for ValidationError",
+		},
+		{
+			"c.unmarshalResponse(body, genericErr, contentType, false)",
+			"handleErrorResponse not passing false (strict) for Error",
+		},
+		{
+			"Always use strict mode (false) for error parsing",
+			"handleErrorResponse missing comment explaining strict mode",
+		},
+	}
+	for _, c := range checks {
+		if !strings.Contains(s, c.pattern) {
+			t.Error(c.msg)
+		}
+	}
+}
 
-			// Verify signature has discardUnknown parameter
-			if !strings.Contains(s, "unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error") {
-				t.Errorf("%s: unmarshalResponse missing discardUnknown parameter", f)
-			}
-			// Verify opts built from discardUnknown
-			if !strings.Contains(s, "opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}") {
-				t.Errorf("%s: unmarshalResponse not building opts from discardUnknown", f)
-			}
-			// Verify sebufUnmarshaler checked first
-			if !strings.Contains(s, "if u, ok := msg.(sebufUnmarshaler); ok {") {
-				t.Errorf("%s: unmarshalResponse not checking sebufUnmarshaler", f)
-			}
-			if !strings.Contains(s, "return u.UnmarshalJSONSebuf(body, opts)") {
-				t.Errorf("%s: unmarshalResponse not calling UnmarshalJSONSebuf", f)
-			}
-		}
-	})
+// TestSSEEventStreamDiscardSupport verifies SSE streaming honors discardUnknownFields.
+func TestSSEEventStreamDiscardSupport(t *testing.T) {
+	s := readGolden(t, "sse_client.pb.go")
 
-	// Verify client struct has discardUnknownFields field
-	t.Run("client_struct_has_discardUnknownFields", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
+	checks := []struct {
+		pattern string
+		msg     string
+	}{
+		{"discardUnknownFields bool", "EventStream missing discardUnknownFields field"},
+		{"discardUnknownFields: discardUnknown,", "SSE method not passing discardUnknown"},
+		{
+			"opts := protojson.UnmarshalOptions{DiscardUnknown: s.discardUnknownFields}",
+			"EventStream.Next not building opts",
+		},
+		{
+			"if u, ok := any(event).(sebufUnmarshaler); ok {",
+			"EventStream.Next not checking sebufUnmarshaler",
+		},
+		{
+			"unmarshalErr = u.UnmarshalJSONSebuf([]byte(data), opts)",
+			"EventStream.Next not calling UnmarshalJSONSebuf",
+		},
+	}
+	for _, c := range checks {
+		if !strings.Contains(s, c.pattern) {
+			t.Error(c.msg)
 		}
-		s := string(content)
+	}
+}
 
-		if !strings.Contains(s, "discardUnknownFields bool") {
-			t.Error("client struct missing discardUnknownFields field")
-		}
-	})
+// TestOptsForwardingToChildren verifies wrapper, flatten, and oneof generators
+// forward opts to nested children.
+func TestOptsForwardingToChildren(t *testing.T) {
+	files := []struct {
+		file string
+		name string
+	}{
+		{"int64_nested_encoding_encoding.pb.go", "wrapper"},
+		{"flatten_flatten.pb.go", "flatten"},
+		{"oneof_discriminator_oneof_discriminator.pb.go", "oneof_discriminator"},
+	}
 
-	// Verify call options struct has *bool for per-call override
-	t.Run("call_options_has_pointer_bool", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
+	for _, f := range files {
+		s := readGolden(t, f.file)
+		pattern := "UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error"
+		if !strings.Contains(s, pattern) {
+			t.Errorf("%s not checking child for UnmarshalJSONSebuf", f.name)
 		}
-		s := string(content)
+	}
+}
 
-		if !strings.Contains(s, "discardUnknownFields *bool") {
-			t.Error("call options missing discardUnknownFields *bool field")
-		}
-	})
+// TestI32_UnmarshalJSONStillPresent verifies backward compat with json.Unmarshaler.
+func TestI32_UnmarshalJSONStillPresent(t *testing.T) {
+	encodingFiles := []encodingFileSpec{
+		{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
+		{"nullable_nullable.pb.go", []string{"User"}},
+		{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
+		{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
+		{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
+		{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
+	}
 
-	// Verify WithXxxDiscardUnknownFields option generated
-	t.Run("client_option_generated", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "func WithNoAnnotationsServiceDiscardUnknownFields(discard bool)") {
-			t.Error("missing WithNoAnnotationsServiceDiscardUnknownFields option")
-		}
-	})
-
-	// Verify WithXxxCallDiscardUnknownFields option generated with pointer semantics
-	t.Run("call_option_generated_with_pointer", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "func WithNoAnnotationsServiceCallDiscardUnknownFields(discard bool)") {
-			t.Error("missing WithNoAnnotationsServiceCallDiscardUnknownFields option")
-		}
-		if !strings.Contains(s, "o.discardUnknownFields = &discard") {
-			t.Error("call option not using pointer assignment")
-		}
-	})
-
-	// Verify discardUnknown resolution in RPC methods
-	t.Run("rpc_method_resolves_discard_option", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "discardUnknown := c.discardUnknownFields") {
-			t.Error("RPC method not reading client-level discardUnknownFields")
-		}
-		if !strings.Contains(s, "if callOpts.discardUnknownFields != nil {") {
-			t.Error("RPC method not checking per-call override")
-		}
-		if !strings.Contains(s, "discardUnknown = *callOpts.discardUnknownFields") {
-			t.Error("RPC method not applying per-call override")
-		}
-	})
-
-	// G.29 — handleErrorResponse always uses strict mode (false)
-	t.Run("G29_handleErrorResponse_strict_mode", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "backward_compat_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "c.unmarshalResponse(body, validationErr, contentType, false)") {
-			t.Error("handleErrorResponse not passing false (strict) for ValidationError")
-		}
-		if !strings.Contains(s, "c.unmarshalResponse(body, genericErr, contentType, false)") {
-			t.Error("handleErrorResponse not passing false (strict) for Error")
-		}
-		if !strings.Contains(s, "Always use strict mode (false) for error parsing") {
-			t.Error("handleErrorResponse missing comment explaining strict mode")
-		}
-	})
-
-	// SSE EventStream tests
-	t.Run("SSE_EventStream_has_discardUnknownFields", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "sse_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		// Verify EventStream struct has discardUnknownFields
-		if !strings.Contains(s, "discardUnknownFields bool") {
-			t.Error("EventStream missing discardUnknownFields field")
-		}
-
-		// Verify SSE method resolves and passes discardUnknown
-		if !strings.Contains(s, "discardUnknownFields: discardUnknown,") {
-			t.Error("SSE method not passing discardUnknown to EventStream")
-		}
-	})
-
-	// Verify SSE Next() method uses sebufUnmarshaler
-	t.Run("SSE_Next_uses_sebufUnmarshaler", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "sse_client.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "opts := protojson.UnmarshalOptions{DiscardUnknown: s.discardUnknownFields}") {
-			t.Error("EventStream.Next not building opts from discardUnknownFields")
-		}
-		if !strings.Contains(s, "if u, ok := any(event).(sebufUnmarshaler); ok {") {
-			t.Error("EventStream.Next not checking sebufUnmarshaler")
-		}
-		if !strings.Contains(s, "unmarshalErr = u.UnmarshalJSONSebuf([]byte(data), opts)") {
-			t.Error("EventStream.Next not calling UnmarshalJSONSebuf")
-		}
-	})
-
-	// Verify wrapper types forward opts to nested children
-	t.Run("wrapper_forwards_opts_to_children", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "int64_nested_encoding_encoding.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error") {
-			t.Error("wrapper not checking child for UnmarshalJSONSebuf")
-		}
-		if !strings.Contains(s, "u.UnmarshalJSONSebuf(rawVal, opts)") {
-			t.Error("wrapper not forwarding opts to child UnmarshalJSONSebuf")
-		}
-	})
-
-	// Verify flatten forwards opts to children
-	t.Run("flatten_forwards_opts_to_children", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "flatten_flatten.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error") {
-			t.Error("flatten not checking child for UnmarshalJSONSebuf")
-		}
-	})
-
-	// Verify oneof_discriminator forwards opts to children
-	t.Run("oneof_discriminator_forwards_opts_to_children", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "oneof_discriminator_oneof_discriminator.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if !strings.Contains(s, "UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error") {
-			t.Error("oneof_discriminator not checking child for UnmarshalJSONSebuf")
-		}
-	})
-
-	// I.32 — UnmarshalJSON still present on every annotated message
-	t.Run("I32_UnmarshalJSON_still_present", func(t *testing.T) {
-		encodingFiles := []struct {
-			file     string
-			msgNames []string
-		}{
-			{"int64_encoding_encoding.pb.go", []string{"Int64EncodingTest"}},
-			{"nullable_nullable.pb.go", []string{"User"}},
-			{"timestamp_format_timestamp_format.pb.go", []string{"TimestampFormatTest"}},
-			{"bytes_encoding_bytes_encoding.pb.go", []string{"BytesEncodingTest"}},
-			{"flatten_flatten.pb.go", []string{"SimpleFlatten", "DualFlatten", "MixedFlatten"}},
-			{"oneof_discriminator_oneof_discriminator.pb.go", []string{"FlattenedEvent", "NestedEvent"}},
-		}
-
-		for _, ef := range encodingFiles {
-			content, err := os.ReadFile(filepath.Join(goldenDir, ef.file))
-			if err != nil {
-				t.Fatalf("Failed to read %s: %v", ef.file, err)
-			}
-			s := string(content)
-			for _, msg := range ef.msgNames {
-				wrapperSig := "func (x *" + msg + ") UnmarshalJSON(data []byte) error {"
-				if !strings.Contains(s, wrapperSig) {
-					t.Errorf("%s: %s missing UnmarshalJSON (json.Unmarshaler compat)", ef.file, msg)
-				}
+	for _, ef := range encodingFiles {
+		s := readGolden(t, ef.file)
+		for _, msg := range ef.msgNames {
+			wrapperSig := "func (x *" + msg + ") UnmarshalJSON(data []byte) error {"
+			if !strings.Contains(s, wrapperSig) {
+				t.Errorf(
+					"%s: %s missing UnmarshalJSON (json.Unmarshaler compat)",
+					ef.file, msg,
+				)
 			}
 		}
-	})
+	}
+}
 
-	// I.34 — Existing call sites compile unchanged (purely additive)
-	// This is tested by TestGeneratedClientCodeCompiles in golden_test.go
+// TestEnumTypesNoUnmarshalJSONSebuf verifies enums don't get the new interface.
+func TestEnumTypesNoUnmarshalJSONSebuf(t *testing.T) {
+	s := readGolden(t, "enum_encoding_enum_encoding.pb.go")
 
-	// Verify enum types do NOT get UnmarshalJSONSebuf (they use direct parsing)
-	t.Run("enum_types_no_UnmarshalJSONSebuf", func(t *testing.T) {
-		content, err := os.ReadFile(filepath.Join(goldenDir, "enum_encoding_enum_encoding.pb.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(content)
-
-		if strings.Contains(s, "UnmarshalJSONSebuf") {
-			t.Error("enum encoding should NOT have UnmarshalJSONSebuf (enums don't use protojson.Unmarshal)")
-		}
-		// But should still have UnmarshalJSON
-		if !strings.Contains(s, "func (x *Status) UnmarshalJSON(data []byte) error {") {
-			t.Error("enum encoding missing UnmarshalJSON")
-		}
-	})
+	if strings.Contains(s, "UnmarshalJSONSebuf") {
+		t.Error("enum encoding should NOT have UnmarshalJSONSebuf")
+	}
+	if !strings.Contains(s, "func (x *Status) UnmarshalJSON(data []byte) error {") {
+		t.Error("enum encoding missing UnmarshalJSON")
+	}
 }
 
 // TestForwardCompatIntegration is an end-to-end integration test that generates code,
 // creates a temporary Go module with httptest-based tests, and runs them.
 // This covers test groups A-J from the test matrix.
-//
-//nolint:funlen // Integration test requires many sequential steps
 func TestForwardCompatIntegration(t *testing.T) {
 	if _, err := exec.LookPath("protoc"); err != nil {
 		t.Skip("protoc not found, skipping integration test")
@@ -388,12 +320,7 @@ func TestForwardCompatIntegration(t *testing.T) {
 		}
 	}
 
-	// Create temp module
 	tempDir := t.TempDir()
-
-	// Generate code for backward_compat.proto (plain proto, no custom unmarshalers)
-	// This tests the core discard-unknown-fields plumbing (groups A, B, C, G, H)
-	// Int64/SSE/annotation-specific tests are covered by TestForwardCompatGoldenPatterns
 	genDir := filepath.Join(tempDir, "gen")
 	if mkErr := os.MkdirAll(genDir, 0o755); mkErr != nil {
 		t.Fatal(mkErr)
@@ -412,31 +339,51 @@ func TestForwardCompatIntegration(t *testing.T) {
 	cmd.Dir = protoDir
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
-		t.Fatalf("protoc backward_compat.proto failed: %v\n%s", runErr, string(out))
+		t.Fatalf("protoc failed: %v\n%s", runErr, string(out))
 	}
 
-	// Get the sebuf module version for replace directive
-	goModContent, readErr := os.ReadFile(filepath.Join(projectRoot, "go.mod"))
-	if readErr != nil {
-		t.Fatal(readErr)
+	protobufVersion := extractProtobufVersion(t, projectRoot)
+	writeTestModule(t, tempDir, projectRoot, protobufVersion)
+
+	// Run the tests
+	testCmd := exec.Command("go", "test", "-v", "-count=1", "./...")
+	testCmd.Dir = tempDir
+	testOut, testErr := testCmd.CombinedOutput()
+
+	t.Logf("Test output:\n%s", string(testOut))
+
+	if testErr != nil {
+		t.Fatalf("integration tests failed: %v", testErr)
+	}
+}
+
+func extractProtobufVersion(t *testing.T, projectRoot string) string {
+	t.Helper()
+	goModContent, err := os.ReadFile(filepath.Join(projectRoot, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	// Extract the protobuf dependency version
-	var protobufVersion string
 	for _, line := range strings.Split(string(goModContent), "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "google.golang.org/protobuf") && !strings.HasPrefix(line, "module") {
+		if strings.HasPrefix(line, "google.golang.org/protobuf") &&
+			!strings.HasPrefix(line, "module") {
 			parts := strings.Fields(line)
 			if len(parts) >= 2 {
-				protobufVersion = parts[1]
+				return parts[1]
 			}
 		}
 	}
-	if protobufVersion == "" {
-		t.Fatal("Could not find google.golang.org/protobuf version in go.mod")
-	}
+	t.Fatal("Could not find google.golang.org/protobuf version in go.mod")
+	return ""
+}
 
-	// Write go.mod
+func writeTestModule(
+	t *testing.T,
+	tempDir, projectRoot, protobufVersion string,
+) {
+	t.Helper()
+
 	goMod := `module forward_compat_test
 
 go 1.24
@@ -448,12 +395,30 @@ require (
 
 replace github.com/SebastienMelki/sebuf => ` + projectRoot + `
 `
-	if writeErr := os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goMod), 0o644); writeErr != nil {
-		t.Fatal(writeErr)
+	if err := os.WriteFile(
+		filepath.Join(tempDir, "go.mod"), []byte(goMod), 0o644,
+	); err != nil {
+		t.Fatal(err)
 	}
 
-	// Write the httptest-based test file
-	testCode := `package forward_compat_test
+	testCode := generateIntegrationTestCode()
+	if err := os.WriteFile(
+		filepath.Join(tempDir, "forward_compat_test.go"), []byte(testCode), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run go mod tidy
+	tidyCmd := exec.Command("go", "mod", "tidy")
+	tidyCmd.Dir = tempDir
+	tidyOut, tidyErr := tidyCmd.CombinedOutput()
+	if tidyErr != nil {
+		t.Fatalf("go mod tidy failed: %v\n%s", tidyErr, string(tidyOut))
+	}
+}
+
+func generateIntegrationTestCode() string {
+	return `package forward_compat_test
 
 import (
 	"context"
@@ -466,7 +431,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// jsonHandler returns an HTTP handler that serves the given JSON body.
 func jsonHandler(body string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -474,7 +438,6 @@ func jsonHandler(body string) http.HandlerFunc {
 	}
 }
 
-// errorHandler returns an HTTP handler that serves an error response.
 func errorHandler(statusCode int, body string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -483,10 +446,9 @@ func errorHandler(statusCode int, body string) http.HandlerFunc {
 	}
 }
 
-// ---- A. Default behavior (compat guarantee) ----
+// ---- A. Default behavior ----
 
 func TestA1_NoOption_UnknownField_PlainMessage_Rejects(t *testing.T) {
-	// Server returns JSON with an unknown field for a plain proto message
 	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
 	defer srv.Close()
 
@@ -527,7 +489,6 @@ func TestB6_ClientDefault_MatchesStrict(t *testing.T) {
 	srv := httptest.NewServer(jsonHandler(` + "`" + `{"unknownField": "value"}` + "`" + `))
 	defer srv.Close()
 
-	// No option set — should be strict (same as A1)
 	client := gen.NewNoAnnotationsServiceClient(srv.URL)
 	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{})
 	if err == nil {
@@ -583,7 +544,7 @@ func TestC10_ClientFalse_PerCallTrue_Succeeds(t *testing.T) {
 	_, err := client.SimpleAction(context.Background(), &gen.SimpleRequest{},
 		gen.WithNoAnnotationsServiceCallDiscardUnknownFields(true))
 	if err != nil {
-		t.Fatalf("expected success: per-call true should override client false, got: %v", err)
+		t.Fatalf("per-call true should override client false, got: %v", err)
 	}
 }
 
@@ -603,7 +564,6 @@ func TestC11_ClientTrue_PerCallTrue_Succeeds(t *testing.T) {
 // ---- G. Error response path ----
 
 func TestG28_ErrorResponse_WithDiscard_StaysStrict(t *testing.T) {
-	// Server returns 400 with extras — client has discard=true but error parsing should still be strict
 	errorBody := ` + "`" + `{"code": 400, "message": "bad request", "unknownField": "extra"}` + "`" + `
 	srv := httptest.NewServer(errorHandler(400, errorBody))
 	defer srv.Close()
@@ -614,15 +574,11 @@ func TestG28_ErrorResponse_WithDiscard_StaysStrict(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error response")
 	}
-	// The error should be returned (handleErrorResponse uses false for unmarshal,
-	// but falls back to raw error if strict unmarshal of ValidationError/Error fails)
-	// Key: we should get an error, not a nil response
 }
 
 // ---- H. Content type branches ----
 
 func TestH30_ProtoContentType_DiscardNoOp(t *testing.T) {
-	// Server returns proto bytes — discard=true should be ignored (proto doesn't have unknowns concept at JSON level)
 	msg := &gen.SimpleResponse{}
 	protoBytes, _ := proto.Marshal(msg)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -645,7 +601,6 @@ func TestH31_EmptyBody_DiscardReturnsNil(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		// empty body
 	}))
 	defer srv.Close()
 
@@ -656,29 +611,5 @@ func TestH31_EmptyBody_DiscardReturnsNil(t *testing.T) {
 		t.Fatalf("expected empty body to return nil with discard=true, got: %v", err)
 	}
 }
-
 `
-
-	if writeErr := os.WriteFile(filepath.Join(tempDir, "forward_compat_test.go"), []byte(testCode), 0o644); writeErr != nil {
-		t.Fatal(writeErr)
-	}
-
-	// Run go mod tidy
-	tidyCmd := exec.Command("go", "mod", "tidy")
-	tidyCmd.Dir = tempDir
-	tidyOut, tidyErr := tidyCmd.CombinedOutput()
-	if tidyErr != nil {
-		t.Fatalf("go mod tidy failed: %v\n%s", tidyErr, string(tidyOut))
-	}
-
-	// Run the tests
-	testCmd := exec.Command("go", "test", "-v", "-count=1", "./...")
-	testCmd.Dir = tempDir
-	testOut, testErr := testCmd.CombinedOutput()
-
-	t.Logf("Test output:\n%s", string(testOut))
-
-	if testErr != nil {
-		t.Fatalf("integration tests failed: %v", testErr)
-	}
 }

--- a/internal/clientgen/generator.go
+++ b/internal/clientgen/generator.go
@@ -113,6 +113,9 @@ func (g *Generator) generateClientFile(file *protogen.File) error {
 	// Generate content type constants once at file level
 	g.generateContentTypeConstants(gf)
 
+	// Generate sebufUnmarshaler interface once at file level
+	g.generateSebufUnmarshalerInterface(gf)
+
 	for _, service := range file.Services {
 		if err := g.generateServiceClient(gf, file, service); err != nil {
 			return err
@@ -291,6 +294,7 @@ func (g *Generator) generateClientStruct(gf *protogen.GeneratedFile, serviceName
 	gf.P("httpClient *http.Client")
 	gf.P("contentType string")
 	gf.P("defaultHeaders map[string]string")
+	gf.P("discardUnknownFields bool")
 	gf.P("}")
 	gf.P()
 
@@ -306,6 +310,15 @@ func (g *Generator) generateContentTypeConstants(gf *protogen.GeneratedFile) {
 	gf.P("// ContentTypeProto is the content type for binary protobuf requests/responses.")
 	gf.P(`ContentTypeProto = "application/x-protobuf"`)
 	gf.P(")")
+	gf.P()
+}
+
+func (g *Generator) generateSebufUnmarshalerInterface(gf *protogen.GeneratedFile) {
+	gf.P("// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.")
+	gf.P("// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.")
+	gf.P("type sebufUnmarshaler interface {")
+	gf.P("UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error")
+	gf.P("}")
 	gf.P()
 }
 
@@ -346,6 +359,16 @@ func (g *Generator) generateClientOptions(gf *protogen.GeneratedFile, serviceNam
 	gf.P("}")
 	gf.P("}")
 	gf.P()
+
+	// With{Service}DiscardUnknownFields
+	gf.P("// With", serviceName, "DiscardUnknownFields sets whether to discard unknown fields in JSON responses.")
+	gf.P("// When true, unknown fields are silently ignored instead of causing unmarshal errors.")
+	gf.P("func With", serviceName, "DiscardUnknownFields(discard bool) ", serviceName, "ClientOption {")
+	gf.P("return func(c *", lowerName, "Client) {")
+	gf.P("c.discardUnknownFields = discard")
+	gf.P("}")
+	gf.P("}")
+	gf.P()
 }
 
 func (g *Generator) generateCallOptions(gf *protogen.GeneratedFile, serviceName string) {
@@ -361,6 +384,7 @@ func (g *Generator) generateCallOptions(gf *protogen.GeneratedFile, serviceName 
 	gf.P("type ", lowerName, "CallOptions struct {")
 	gf.P("headers map[string]string")
 	gf.P("contentType string")
+	gf.P("discardUnknownFields *bool")
 	gf.P("}")
 	gf.P()
 
@@ -381,6 +405,19 @@ func (g *Generator) generateCallOptions(gf *protogen.GeneratedFile, serviceName 
 	gf.P("func With", serviceName, "CallContentType(contentType string) ", serviceName, "CallOption {")
 	gf.P("return func(o *", lowerName, "CallOptions) {")
 	gf.P("o.contentType = contentType")
+	gf.P("}")
+	gf.P("}")
+	gf.P()
+
+	// With{Service}CallDiscardUnknownFields
+	gf.P(
+		"// With", serviceName,
+		"CallDiscardUnknownFields sets whether to discard unknown fields for a single request.",
+	)
+	gf.P("// Overrides the client-level setting from With", serviceName, "DiscardUnknownFields.")
+	gf.P("func With", serviceName, "CallDiscardUnknownFields(discard bool) ", serviceName, "CallOption {")
+	gf.P("return func(o *", lowerName, "CallOptions) {")
+	gf.P("o.discardUnknownFields = &discard")
 	gf.P("}")
 	gf.P("}")
 	gf.P()
@@ -622,10 +659,18 @@ func (g *Generator) generateSSERPCMethod(
 	gf.P("}")
 	gf.P()
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	gf.P("discardUnknown := c.discardUnknownFields")
+	gf.P("if callOpts.discardUnknownFields != nil {")
+	gf.P("discardUnknown = *callOpts.discardUnknownFields")
+	gf.P("}")
+	gf.P()
+
 	// Return EventStream
 	gf.P("return &", cfg.serviceName, "EventStream[*", method.Output.GoIdent, "]{")
-	gf.P("resp:    resp,")
-	gf.P("reader: bufio.NewReader(resp.Body),")
+	gf.P("resp:                 resp,")
+	gf.P("reader:               bufio.NewReader(resp.Body),")
+	gf.P("discardUnknownFields: discardUnknown,")
 	gf.P("}, nil")
 	gf.P("}")
 	gf.P()
@@ -721,9 +766,15 @@ func (g *Generator) generateRPCMethodResponse(gf *protogen.GeneratedFile, method
 	gf.P("return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)")
 	gf.P("}")
 	gf.P()
+	gf.P("// Resolve discardUnknownFields: per-call option overrides client default")
+	gf.P("discardUnknown := c.discardUnknownFields")
+	gf.P("if callOpts.discardUnknownFields != nil {")
+	gf.P("discardUnknown = *callOpts.discardUnknownFields")
+	gf.P("}")
+	gf.P()
 	gf.P("// Unmarshal response")
 	gf.P("result := &", method.Output.GoIdent, "{}")
-	gf.P("if err := c.unmarshalResponse(respBody, result, contentType); err != nil {")
+	gf.P("if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {")
 	gf.P("return nil, fmt.Errorf(\"failed to unmarshal response: %w\", err)")
 	gf.P("}")
 	gf.P()
@@ -811,16 +862,18 @@ func (g *Generator) generateMarshalRequestMethod(gf *protogen.GeneratedFile, low
 func (g *Generator) generateHandleErrorResponseMethod(gf *protogen.GeneratedFile, lowerName string) {
 	gf.P("func (c *", lowerName, "Client) handleErrorResponse(statusCode int, body []byte, contentType string) error {")
 	gf.P("// Try to parse as ValidationError first (for 400 errors)")
+	gf.P("// Always use strict mode (false) for error parsing to avoid loose JSON")
+	gf.P("// falsely matching ValidationError or Error types.")
 	gf.P("if statusCode == http.StatusBadRequest {")
 	gf.P("validationErr := &sebufhttp.ValidationError{}")
-	gf.P("if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {")
+	gf.P("if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {")
 	gf.P("return validationErr")
 	gf.P("}")
 	gf.P("}")
 	gf.P()
 	gf.P("// Try to parse as generic Error")
 	gf.P("genericErr := &sebufhttp.Error{}")
-	gf.P("if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {")
+	gf.P("if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {")
 	gf.P("return genericErr")
 	gf.P("}")
 	gf.P()
@@ -834,23 +887,29 @@ func (g *Generator) generateUnmarshalResponseMethod(gf *protogen.GeneratedFile, 
 	gf.P(
 		"func (c *",
 		lowerName,
-		"Client) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {",
+		"Client) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {",
 	)
 	gf.P("if len(body) == 0 {")
 	gf.P("return nil")
 	gf.P("}")
 	gf.P()
+	gf.P("opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}")
+	gf.P()
 	gf.P("switch contentType {")
 	gf.P("case ContentTypeJSON:")
-	gf.P("// Check for custom JSON unmarshaler (unwrap support)")
-	gf.P("if unmarshaler, ok := msg.(json.Unmarshaler); ok {")
-	gf.P("return unmarshaler.UnmarshalJSON(body)")
+	gf.P("// Check for sebuf-generated custom unmarshaler (passes options through)")
+	gf.P("if u, ok := msg.(sebufUnmarshaler); ok {")
+	gf.P("return u.UnmarshalJSONSebuf(body, opts)")
 	gf.P("}")
-	gf.P("return protojson.Unmarshal(body, msg)")
+	gf.P("// Check for third-party json.Unmarshaler (best effort, cannot pass options)")
+	gf.P("if u, ok := msg.(json.Unmarshaler); ok {")
+	gf.P("return u.UnmarshalJSON(body)")
+	gf.P("}")
+	gf.P("return opts.Unmarshal(body, msg)")
 	gf.P("case ContentTypeProto:")
 	gf.P("return proto.Unmarshal(body, msg)")
 	gf.P("default:")
-	gf.P("return protojson.Unmarshal(body, msg)")
+	gf.P("return opts.Unmarshal(body, msg)")
 	gf.P("}")
 	gf.P("}")
 	gf.P()
@@ -903,9 +962,10 @@ func (g *Generator) serviceHasSSEMethods(service *protogen.Service) bool {
 func (g *Generator) generateEventStreamType(gf *protogen.GeneratedFile, serviceName string) {
 	gf.P("// ", serviceName, "EventStream reads Server-Sent Events from a streaming endpoint.")
 	gf.P("type ", serviceName, "EventStream[T proto.Message] struct {")
-	gf.P("resp   *http.Response")
-	gf.P("reader *bufio.Reader")
-	gf.P("err    error")
+	gf.P("resp                 *http.Response")
+	gf.P("reader               *bufio.Reader")
+	gf.P("err                  error")
+	gf.P("discardUnknownFields bool")
 	gf.P("}")
 	gf.P()
 
@@ -925,8 +985,17 @@ func (g *Generator) generateEventStreamType(gf *protogen.GeneratedFile, serviceN
 	gf.P("continue")
 	gf.P("}")
 	gf.P(`data := strings.TrimPrefix(line, "data: ")`)
-	gf.P("if err := protojson.Unmarshal([]byte(data), event); err != nil {")
-	gf.P(`s.err = fmt.Errorf("failed to unmarshal SSE event: %w", err)`)
+	gf.P("opts := protojson.UnmarshalOptions{DiscardUnknown: s.discardUnknownFields}")
+	gf.P("var unmarshalErr error")
+	gf.P("if u, ok := any(event).(sebufUnmarshaler); ok {")
+	gf.P("unmarshalErr = u.UnmarshalJSONSebuf([]byte(data), opts)")
+	gf.P("} else if u, ok := any(event).(json.Unmarshaler); ok {")
+	gf.P("unmarshalErr = u.UnmarshalJSON([]byte(data))")
+	gf.P("} else {")
+	gf.P("unmarshalErr = opts.Unmarshal([]byte(data), event)")
+	gf.P("}")
+	gf.P("if unmarshalErr != nil {")
+	gf.P(`s.err = fmt.Errorf("failed to unmarshal SSE event: %w", unmarshalErr)`)
 	gf.P("return false")
 	gf.P("}")
 	gf.P("return true")

--- a/internal/clientgen/generator.go
+++ b/internal/clientgen/generator.go
@@ -959,6 +959,8 @@ func (g *Generator) serviceHasSSEMethods(service *protogen.Service) bool {
 }
 
 // generateEventStreamType generates the EventStream generic type for SSE streaming.
+//
+//nolint:funlen // SSE event stream generation requires many sequential code blocks
 func (g *Generator) generateEventStreamType(gf *protogen.GeneratedFile, serviceName string) {
 	gf.P("// ", serviceName, "EventStream reads Server-Sent Events from a streaming endpoint.")
 	gf.P("type ", serviceName, "EventStream[T proto.Message] struct {")

--- a/internal/clientgen/nullable.go
+++ b/internal/clientgen/nullable.go
@@ -171,9 +171,9 @@ func (g *Generator) generateNullableUnmarshalJSON(gf *protogen.GeneratedFile, ct
 		fieldNames = append(fieldNames, string(f.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles nullable fields: ", strings.Join(fieldNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("// Parse to check for explicit null values on nullable fields")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
@@ -200,7 +200,14 @@ func (g *Generator) generateNullableUnmarshalJSON(gf *protogen.GeneratedFile, ct
 	gf.P("return err")
 	gf.P("}")
 	gf.P()
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }

--- a/internal/clientgen/oneof_discriminator.go
+++ b/internal/clientgen/oneof_discriminator.go
@@ -265,9 +265,9 @@ func (g *Generator) generateOneofUnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 		oneofNames = append(oneofNames, string(info.Oneof.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles oneof discriminator fields: ", strings.Join(oneofNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("// Parse into a map to read discriminator fields")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
@@ -291,7 +291,14 @@ func (g *Generator) generateOneofUnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 	gf.P("return err")
 	gf.P("}")
 	gf.P()
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }
@@ -360,7 +367,11 @@ func (g *Generator) generateFlattenedUnmarshal(
 
 	gf.P("variantData, _ := json.Marshal(variantMap)")
 	gf.P("variant := &", msgType, "{}")
-	gf.P("if err := json.Unmarshal(variantData, variant); err != nil {")
+	gf.P("if u, ok := any(variant).(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {")
+	gf.P("if err := u.UnmarshalJSONSebuf(variantData, opts); err != nil {")
+	gf.P(`return fmt.Errorf("failed to unmarshal variant %s: %%w", "`, fieldGoName, `", err)`)
+	gf.P("}")
+	gf.P("} else if err := json.Unmarshal(variantData, variant); err != nil {")
 	gf.P(`return fmt.Errorf("failed to unmarshal variant %s: %%w", "`, fieldGoName, `", err)`)
 	gf.P("}")
 	gf.P("x.", info.Oneof.GoName, " = &", wrapperType, "{", fieldGoName, ": variant}")
@@ -383,10 +394,14 @@ func (g *Generator) generateNestedUnmarshal(
 	wrapperType := variant.Field.GoIdent.GoName
 	msgType := variant.Field.Message.GoIdent.GoName
 
-	gf.P("// Non-flattened unmarshal: use json.Unmarshal for child UnmarshalJSON support")
+	gf.P("// Non-flattened unmarshal: forward opts to child's UnmarshalJSONSebuf if available")
 	gf.P(`if variantRaw, exists := raw["`, fieldJSONName, `"]; exists {`)
 	gf.P("variant := &", msgType, "{}")
-	gf.P("if err := json.Unmarshal(variantRaw, variant); err != nil {")
+	gf.P("if u, ok := any(variant).(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {")
+	gf.P("if err := u.UnmarshalJSONSebuf(variantRaw, opts); err != nil {")
+	gf.P(`return fmt.Errorf("failed to unmarshal variant %s: %%w", "`, fieldGoName, `", err)`)
+	gf.P("}")
+	gf.P("} else if err := json.Unmarshal(variantRaw, variant); err != nil {")
 	gf.P(`return fmt.Errorf("failed to unmarshal variant %s: %%w", "`, fieldGoName, `", err)`)
 	gf.P("}")
 	gf.P("x.", info.Oneof.GoName, " = &", wrapperType, "{", fieldGoName, ": variant}")

--- a/internal/clientgen/testdata/golden/backward_compat_client.pb.go
+++ b/internal/clientgen/testdata/golden/backward_compat_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // NoAnnotationsServiceClient is the client API for NoAnnotationsService service.
 type NoAnnotationsServiceClient interface {
 	SimpleAction(ctx context.Context, req *SimpleRequest, opts ...NoAnnotationsServiceCallOption) (*SimpleResponse, error)
@@ -33,10 +39,11 @@ type NoAnnotationsServiceClient interface {
 
 // noAnnotationsServiceClient is the implementation of NoAnnotationsServiceClient.
 type noAnnotationsServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ NoAnnotationsServiceClient = (*noAnnotationsServiceClient)(nil)
@@ -69,13 +76,22 @@ func WithNoAnnotationsServiceDefaultHeader(key, value string) NoAnnotationsServi
 	}
 }
 
+// WithNoAnnotationsServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithNoAnnotationsServiceDiscardUnknownFields(discard bool) NoAnnotationsServiceClientOption {
+	return func(c *noAnnotationsServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // NoAnnotationsServiceCallOption configures a single RPC call.
 type NoAnnotationsServiceCallOption func(*noAnnotationsServiceCallOptions)
 
 // noAnnotationsServiceCallOptions holds options for a single RPC call.
 type noAnnotationsServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithNoAnnotationsServiceHeader adds a header to a single request.
@@ -92,6 +108,14 @@ func WithNoAnnotationsServiceHeader(key, value string) NoAnnotationsServiceCallO
 func WithNoAnnotationsServiceCallContentType(contentType string) NoAnnotationsServiceCallOption {
 	return func(o *noAnnotationsServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithNoAnnotationsServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithNoAnnotationsServiceDiscardUnknownFields.
+func WithNoAnnotationsServiceCallDiscardUnknownFields(discard bool) NoAnnotationsServiceCallOption {
+	return func(o *noAnnotationsServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -166,9 +190,15 @@ func (c *noAnnotationsServiceClient) SimpleAction(ctx context.Context, req *Simp
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SimpleResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -230,9 +260,15 @@ func (c *noAnnotationsServiceClient) AnotherAction(ctx context.Context, req *Ano
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &AnotherResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -256,16 +292,18 @@ func (c *noAnnotationsServiceClient) marshalRequest(req proto.Message, contentTy
 
 func (c *noAnnotationsServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -273,22 +311,28 @@ func (c *noAnnotationsServiceClient) handleErrorResponse(statusCode int, body []
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *noAnnotationsServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *noAnnotationsServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }
 
@@ -300,10 +344,11 @@ type BasePathOnlyServiceClient interface {
 
 // basePathOnlyServiceClient is the implementation of BasePathOnlyServiceClient.
 type basePathOnlyServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ BasePathOnlyServiceClient = (*basePathOnlyServiceClient)(nil)
@@ -336,13 +381,22 @@ func WithBasePathOnlyServiceDefaultHeader(key, value string) BasePathOnlyService
 	}
 }
 
+// WithBasePathOnlyServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithBasePathOnlyServiceDiscardUnknownFields(discard bool) BasePathOnlyServiceClientOption {
+	return func(c *basePathOnlyServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // BasePathOnlyServiceCallOption configures a single RPC call.
 type BasePathOnlyServiceCallOption func(*basePathOnlyServiceCallOptions)
 
 // basePathOnlyServiceCallOptions holds options for a single RPC call.
 type basePathOnlyServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithBasePathOnlyServiceHeader adds a header to a single request.
@@ -359,6 +413,14 @@ func WithBasePathOnlyServiceHeader(key, value string) BasePathOnlyServiceCallOpt
 func WithBasePathOnlyServiceCallContentType(contentType string) BasePathOnlyServiceCallOption {
 	return func(o *basePathOnlyServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithBasePathOnlyServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithBasePathOnlyServiceDiscardUnknownFields.
+func WithBasePathOnlyServiceCallDiscardUnknownFields(discard bool) BasePathOnlyServiceCallOption {
+	return func(o *basePathOnlyServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -433,9 +495,15 @@ func (c *basePathOnlyServiceClient) ActionOne(ctx context.Context, req *ActionRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &ActionResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -497,9 +565,15 @@ func (c *basePathOnlyServiceClient) ActionTwo(ctx context.Context, req *ActionRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &ActionResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -523,16 +597,18 @@ func (c *basePathOnlyServiceClient) marshalRequest(req proto.Message, contentTyp
 
 func (c *basePathOnlyServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -540,21 +616,27 @@ func (c *basePathOnlyServiceClient) handleErrorResponse(statusCode int, body []b
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *basePathOnlyServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *basePathOnlyServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/bytes_encoding_bytes_encoding.pb.go
+++ b/internal/clientgen/testdata/golden/bytes_encoding_bytes_encoding.pb.go
@@ -53,9 +53,9 @@ func (x *BytesEncodingTest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for BytesEncodingTest.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for BytesEncodingTest.
 // This method handles bytes_encoding fields: base64_raw_data, base64url_data, base64url_raw_data, hex_data
-func (x *BytesEncodingTest) UnmarshalJSON(data []byte) error {
+func (x *BytesEncodingTest) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// Parse the raw JSON to extract bytes-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -113,5 +113,10 @@ func (x *BytesEncodingTest) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for BytesEncodingTest.
+func (x *BytesEncodingTest) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/bytes_encoding_client.pb.go
+++ b/internal/clientgen/testdata/golden/bytes_encoding_client.pb.go
@@ -26,6 +26,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // BytesEncodingServiceClient is the client API for BytesEncodingService service.
 type BytesEncodingServiceClient interface {
 	TestBytesEncoding(ctx context.Context, req *BytesEncodingTest, opts ...BytesEncodingServiceCallOption) (*BytesEncodingTest, error)
@@ -34,10 +40,11 @@ type BytesEncodingServiceClient interface {
 
 // bytesEncodingServiceClient is the implementation of BytesEncodingServiceClient.
 type bytesEncodingServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ BytesEncodingServiceClient = (*bytesEncodingServiceClient)(nil)
@@ -70,13 +77,22 @@ func WithBytesEncodingServiceDefaultHeader(key, value string) BytesEncodingServi
 	}
 }
 
+// WithBytesEncodingServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithBytesEncodingServiceDiscardUnknownFields(discard bool) BytesEncodingServiceClientOption {
+	return func(c *bytesEncodingServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // BytesEncodingServiceCallOption configures a single RPC call.
 type BytesEncodingServiceCallOption func(*bytesEncodingServiceCallOptions)
 
 // bytesEncodingServiceCallOptions holds options for a single RPC call.
 type bytesEncodingServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithBytesEncodingServiceHeader adds a header to a single request.
@@ -93,6 +109,14 @@ func WithBytesEncodingServiceHeader(key, value string) BytesEncodingServiceCallO
 func WithBytesEncodingServiceCallContentType(contentType string) BytesEncodingServiceCallOption {
 	return func(o *bytesEncodingServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithBytesEncodingServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithBytesEncodingServiceDiscardUnknownFields.
+func WithBytesEncodingServiceCallDiscardUnknownFields(discard bool) BytesEncodingServiceCallOption {
+	return func(o *bytesEncodingServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -167,9 +191,15 @@ func (c *bytesEncodingServiceClient) TestBytesEncoding(ctx context.Context, req 
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &BytesEncodingTest{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -226,9 +256,15 @@ func (c *bytesEncodingServiceClient) GetBytesEncoding(ctx context.Context, req *
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &BytesEncodingTest{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -252,16 +288,18 @@ func (c *bytesEncodingServiceClient) marshalRequest(req proto.Message, contentTy
 
 func (c *bytesEncodingServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -269,21 +307,27 @@ func (c *bytesEncodingServiceClient) handleErrorResponse(statusCode int, body []
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *bytesEncodingServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *bytesEncodingServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/complex_features_client.pb.go
+++ b/internal/clientgen/testdata/golden/complex_features_client.pb.go
@@ -26,6 +26,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // FeatureServiceClient is the client API for FeatureService service.
 type FeatureServiceClient interface {
 	ListNotes(ctx context.Context, req *ListNotesRequest, opts ...FeatureServiceCallOption) (*ListNotesResponse, error)
@@ -40,10 +46,11 @@ type FeatureServiceClient interface {
 
 // featureServiceClient is the implementation of FeatureServiceClient.
 type featureServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ FeatureServiceClient = (*featureServiceClient)(nil)
@@ -76,13 +83,22 @@ func WithFeatureServiceDefaultHeader(key, value string) FeatureServiceClientOpti
 	}
 }
 
+// WithFeatureServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithFeatureServiceDiscardUnknownFields(discard bool) FeatureServiceClientOption {
+	return func(c *featureServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // FeatureServiceCallOption configures a single RPC call.
 type FeatureServiceCallOption func(*featureServiceCallOptions)
 
 // featureServiceCallOptions holds options for a single RPC call.
 type featureServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithFeatureServiceHeader adds a header to a single request.
@@ -99,6 +115,14 @@ func WithFeatureServiceHeader(key, value string) FeatureServiceCallOption {
 func WithFeatureServiceCallContentType(contentType string) FeatureServiceCallOption {
 	return func(o *featureServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithFeatureServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithFeatureServiceDiscardUnknownFields.
+func WithFeatureServiceCallDiscardUnknownFields(discard bool) FeatureServiceCallOption {
+	return func(o *featureServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -212,9 +236,15 @@ func (c *featureServiceClient) ListNotes(ctx context.Context, req *ListNotesRequ
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &ListNotesResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -271,9 +301,15 @@ func (c *featureServiceClient) GetNote(ctx context.Context, req *GetNoteRequest,
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Note{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -335,9 +371,15 @@ func (c *featureServiceClient) CreateNote(ctx context.Context, req *CreateNoteRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Note{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -400,9 +442,15 @@ func (c *featureServiceClient) UpdateNote(ctx context.Context, req *UpdateNoteRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Note{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -464,9 +512,15 @@ func (c *featureServiceClient) GetNoteList(ctx context.Context, req *GetNoteList
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &NoteList{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -528,9 +582,15 @@ func (c *featureServiceClient) GetNoteMap(ctx context.Context, req *GetNoteMapRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &NoteMap{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -592,9 +652,15 @@ func (c *featureServiceClient) GetBarsBySymbol(ctx context.Context, req *GetBars
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &BarsBySymbol{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -656,9 +722,15 @@ func (c *featureServiceClient) GetCombinedUnwrap(ctx context.Context, req *GetCo
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &CombinedUnwrap{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -682,16 +754,18 @@ func (c *featureServiceClient) marshalRequest(req proto.Message, contentType str
 
 func (c *featureServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -699,21 +773,27 @@ func (c *featureServiceClient) handleErrorResponse(statusCode int, body []byte, 
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *featureServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *featureServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/empty_behavior_client.pb.go
+++ b/internal/clientgen/testdata/golden/empty_behavior_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // EmptyBehaviorServiceClient is the client API for EmptyBehaviorService service.
 type EmptyBehaviorServiceClient interface {
 	GetResponse(ctx context.Context, req *GetResponseRequest, opts ...EmptyBehaviorServiceCallOption) (*Response, error)
@@ -32,10 +38,11 @@ type EmptyBehaviorServiceClient interface {
 
 // emptyBehaviorServiceClient is the implementation of EmptyBehaviorServiceClient.
 type emptyBehaviorServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ EmptyBehaviorServiceClient = (*emptyBehaviorServiceClient)(nil)
@@ -68,13 +75,22 @@ func WithEmptyBehaviorServiceDefaultHeader(key, value string) EmptyBehaviorServi
 	}
 }
 
+// WithEmptyBehaviorServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithEmptyBehaviorServiceDiscardUnknownFields(discard bool) EmptyBehaviorServiceClientOption {
+	return func(c *emptyBehaviorServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // EmptyBehaviorServiceCallOption configures a single RPC call.
 type EmptyBehaviorServiceCallOption func(*emptyBehaviorServiceCallOptions)
 
 // emptyBehaviorServiceCallOptions holds options for a single RPC call.
 type emptyBehaviorServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithEmptyBehaviorServiceHeader adds a header to a single request.
@@ -91,6 +107,14 @@ func WithEmptyBehaviorServiceHeader(key, value string) EmptyBehaviorServiceCallO
 func WithEmptyBehaviorServiceCallContentType(contentType string) EmptyBehaviorServiceCallOption {
 	return func(o *emptyBehaviorServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithEmptyBehaviorServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithEmptyBehaviorServiceDiscardUnknownFields.
+func WithEmptyBehaviorServiceCallDiscardUnknownFields(discard bool) EmptyBehaviorServiceCallOption {
+	return func(o *emptyBehaviorServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -160,9 +184,15 @@ func (c *emptyBehaviorServiceClient) GetResponse(ctx context.Context, req *GetRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Response{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -186,16 +216,18 @@ func (c *emptyBehaviorServiceClient) marshalRequest(req proto.Message, contentTy
 
 func (c *emptyBehaviorServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -203,21 +235,27 @@ func (c *emptyBehaviorServiceClient) handleErrorResponse(statusCode int, body []
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *emptyBehaviorServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *emptyBehaviorServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/empty_behavior_empty_behavior.pb.go
+++ b/internal/clientgen/testdata/golden/empty_behavior_empty_behavior.pb.go
@@ -56,9 +56,9 @@ func (x *Response) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Response.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for Response.
 // This method handles empty_behavior fields: metadata_preserve, metadata_null, metadata_omit, settings
-func (x *Response) UnmarshalJSON(data []byte) error {
+func (x *Response) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// Parse to check for explicit null values on empty_behavior=NULL fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -81,5 +81,10 @@ func (x *Response) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Response.
+func (x *Response) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/enum_encoding_client.pb.go
+++ b/internal/clientgen/testdata/golden/enum_encoding_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // EnumEncodingServiceClient is the client API for EnumEncodingService service.
 type EnumEncodingServiceClient interface {
 	GetEnumTest(ctx context.Context, req *GetEnumTestRequest, opts ...EnumEncodingServiceCallOption) (*EnumEncodingTest, error)
@@ -32,10 +38,11 @@ type EnumEncodingServiceClient interface {
 
 // enumEncodingServiceClient is the implementation of EnumEncodingServiceClient.
 type enumEncodingServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ EnumEncodingServiceClient = (*enumEncodingServiceClient)(nil)
@@ -68,13 +75,22 @@ func WithEnumEncodingServiceDefaultHeader(key, value string) EnumEncodingService
 	}
 }
 
+// WithEnumEncodingServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithEnumEncodingServiceDiscardUnknownFields(discard bool) EnumEncodingServiceClientOption {
+	return func(c *enumEncodingServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // EnumEncodingServiceCallOption configures a single RPC call.
 type EnumEncodingServiceCallOption func(*enumEncodingServiceCallOptions)
 
 // enumEncodingServiceCallOptions holds options for a single RPC call.
 type enumEncodingServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithEnumEncodingServiceHeader adds a header to a single request.
@@ -91,6 +107,14 @@ func WithEnumEncodingServiceHeader(key, value string) EnumEncodingServiceCallOpt
 func WithEnumEncodingServiceCallContentType(contentType string) EnumEncodingServiceCallOption {
 	return func(o *enumEncodingServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithEnumEncodingServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithEnumEncodingServiceDiscardUnknownFields.
+func WithEnumEncodingServiceCallDiscardUnknownFields(discard bool) EnumEncodingServiceCallOption {
+	return func(o *enumEncodingServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -160,9 +184,15 @@ func (c *enumEncodingServiceClient) GetEnumTest(ctx context.Context, req *GetEnu
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &EnumEncodingTest{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -186,16 +216,18 @@ func (c *enumEncodingServiceClient) marshalRequest(req proto.Message, contentTyp
 
 func (c *enumEncodingServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -203,21 +235,27 @@ func (c *enumEncodingServiceClient) handleErrorResponse(statusCode int, body []b
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *enumEncodingServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *enumEncodingServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/flatten_client.pb.go
+++ b/internal/clientgen/testdata/golden/flatten_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // FlattenServiceClient is the client API for FlattenService service.
 type FlattenServiceClient interface {
 	TestSimpleFlatten(ctx context.Context, req *SimpleFlatten, opts ...FlattenServiceCallOption) (*SimpleFlatten, error)
@@ -35,10 +41,11 @@ type FlattenServiceClient interface {
 
 // flattenServiceClient is the implementation of FlattenServiceClient.
 type flattenServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ FlattenServiceClient = (*flattenServiceClient)(nil)
@@ -71,13 +78,22 @@ func WithFlattenServiceDefaultHeader(key, value string) FlattenServiceClientOpti
 	}
 }
 
+// WithFlattenServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithFlattenServiceDiscardUnknownFields(discard bool) FlattenServiceClientOption {
+	return func(c *flattenServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // FlattenServiceCallOption configures a single RPC call.
 type FlattenServiceCallOption func(*flattenServiceCallOptions)
 
 // flattenServiceCallOptions holds options for a single RPC call.
 type flattenServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithFlattenServiceHeader adds a header to a single request.
@@ -94,6 +110,14 @@ func WithFlattenServiceHeader(key, value string) FlattenServiceCallOption {
 func WithFlattenServiceCallContentType(contentType string) FlattenServiceCallOption {
 	return func(o *flattenServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithFlattenServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithFlattenServiceDiscardUnknownFields.
+func WithFlattenServiceCallDiscardUnknownFields(discard bool) FlattenServiceCallOption {
+	return func(o *flattenServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -168,9 +192,15 @@ func (c *flattenServiceClient) TestSimpleFlatten(ctx context.Context, req *Simpl
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SimpleFlatten{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -232,9 +262,15 @@ func (c *flattenServiceClient) TestDualFlatten(ctx context.Context, req *DualFla
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &DualFlatten{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -296,9 +332,15 @@ func (c *flattenServiceClient) TestMixedFlatten(ctx context.Context, req *MixedF
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &MixedFlatten{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -360,9 +402,15 @@ func (c *flattenServiceClient) TestPlainNested(ctx context.Context, req *PlainNe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &PlainNested{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -386,16 +434,18 @@ func (c *flattenServiceClient) marshalRequest(req proto.Message, contentType str
 
 func (c *flattenServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -403,21 +453,27 @@ func (c *flattenServiceClient) handleErrorResponse(statusCode int, body []byte, 
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *flattenServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *flattenServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/flatten_flatten.pb.go
+++ b/internal/clientgen/testdata/golden/flatten_flatten.pb.go
@@ -48,9 +48,9 @@ func (x *SimpleFlatten) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for SimpleFlatten.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for SimpleFlatten.
 // This method handles flatten fields: address
-func (x *SimpleFlatten) UnmarshalJSON(data []byte) error {
+func (x *SimpleFlatten) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -77,8 +77,14 @@ func (x *SimpleFlatten) UnmarshalJSON(data []byte) error {
 				return childErr
 			}
 			x.Address = &Address{}
-			// Use json.Unmarshal to invoke child's UnmarshalJSON (annotation composability)
-			if childErr = json.Unmarshal(childData, x.Address); childErr != nil {
+			// Forward opts to child's UnmarshalJSONSebuf if available (annotation composability)
+			if u, ok := any(x.Address).(interface {
+				UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+			}); ok {
+				if childErr = u.UnmarshalJSONSebuf(childData, opts); childErr != nil {
+					return childErr
+				}
+			} else if childErr = json.Unmarshal(childData, x.Address); childErr != nil {
 				return childErr
 			}
 		}
@@ -90,7 +96,12 @@ func (x *SimpleFlatten) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(remaining, x)
+	return opts.Unmarshal(remaining, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for SimpleFlatten.
+func (x *SimpleFlatten) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSON implements json.Marshaler for DualFlatten.
@@ -149,9 +160,9 @@ func (x *DualFlatten) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for DualFlatten.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for DualFlatten.
 // This method handles flatten fields: billing, shipping
-func (x *DualFlatten) UnmarshalJSON(data []byte) error {
+func (x *DualFlatten) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -178,8 +189,14 @@ func (x *DualFlatten) UnmarshalJSON(data []byte) error {
 				return childErr
 			}
 			x.Billing = &Address{}
-			// Use json.Unmarshal to invoke child's UnmarshalJSON (annotation composability)
-			if childErr = json.Unmarshal(childData, x.Billing); childErr != nil {
+			// Forward opts to child's UnmarshalJSONSebuf if available (annotation composability)
+			if u, ok := any(x.Billing).(interface {
+				UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+			}); ok {
+				if childErr = u.UnmarshalJSONSebuf(childData, opts); childErr != nil {
+					return childErr
+				}
+			} else if childErr = json.Unmarshal(childData, x.Billing); childErr != nil {
 				return childErr
 			}
 		}
@@ -206,8 +223,14 @@ func (x *DualFlatten) UnmarshalJSON(data []byte) error {
 				return childErr
 			}
 			x.Shipping = &Address{}
-			// Use json.Unmarshal to invoke child's UnmarshalJSON (annotation composability)
-			if childErr = json.Unmarshal(childData, x.Shipping); childErr != nil {
+			// Forward opts to child's UnmarshalJSONSebuf if available (annotation composability)
+			if u, ok := any(x.Shipping).(interface {
+				UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+			}); ok {
+				if childErr = u.UnmarshalJSONSebuf(childData, opts); childErr != nil {
+					return childErr
+				}
+			} else if childErr = json.Unmarshal(childData, x.Shipping); childErr != nil {
 				return childErr
 			}
 		}
@@ -219,7 +242,12 @@ func (x *DualFlatten) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(remaining, x)
+	return opts.Unmarshal(remaining, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for DualFlatten.
+func (x *DualFlatten) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSON implements json.Marshaler for MixedFlatten.
@@ -261,9 +289,9 @@ func (x *MixedFlatten) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for MixedFlatten.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for MixedFlatten.
 // This method handles flatten fields: address
-func (x *MixedFlatten) UnmarshalJSON(data []byte) error {
+func (x *MixedFlatten) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -290,8 +318,14 @@ func (x *MixedFlatten) UnmarshalJSON(data []byte) error {
 				return childErr
 			}
 			x.Address = &Address{}
-			// Use json.Unmarshal to invoke child's UnmarshalJSON (annotation composability)
-			if childErr = json.Unmarshal(childData, x.Address); childErr != nil {
+			// Forward opts to child's UnmarshalJSONSebuf if available (annotation composability)
+			if u, ok := any(x.Address).(interface {
+				UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+			}); ok {
+				if childErr = u.UnmarshalJSONSebuf(childData, opts); childErr != nil {
+					return childErr
+				}
+			} else if childErr = json.Unmarshal(childData, x.Address); childErr != nil {
 				return childErr
 			}
 		}
@@ -303,5 +337,10 @@ func (x *MixedFlatten) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(remaining, x)
+	return opts.Unmarshal(remaining, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for MixedFlatten.
+func (x *MixedFlatten) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/http_verbs_comprehensive_client.pb.go
+++ b/internal/clientgen/testdata/golden/http_verbs_comprehensive_client.pb.go
@@ -26,6 +26,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // RESTfulAPIServiceClient is the client API for RESTfulAPIService service.
 type RESTfulAPIServiceClient interface {
 	ListResources(ctx context.Context, req *ListResourcesRequest, opts ...RESTfulAPIServiceCallOption) (*ListResourcesResponse, error)
@@ -41,10 +47,11 @@ type RESTfulAPIServiceClient interface {
 
 // rESTfulAPIServiceClient is the implementation of RESTfulAPIServiceClient.
 type rESTfulAPIServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ RESTfulAPIServiceClient = (*rESTfulAPIServiceClient)(nil)
@@ -77,13 +84,22 @@ func WithRESTfulAPIServiceDefaultHeader(key, value string) RESTfulAPIServiceClie
 	}
 }
 
+// WithRESTfulAPIServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithRESTfulAPIServiceDiscardUnknownFields(discard bool) RESTfulAPIServiceClientOption {
+	return func(c *rESTfulAPIServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // RESTfulAPIServiceCallOption configures a single RPC call.
 type RESTfulAPIServiceCallOption func(*rESTfulAPIServiceCallOptions)
 
 // rESTfulAPIServiceCallOptions holds options for a single RPC call.
 type rESTfulAPIServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithRESTfulAPIServiceHeader adds a header to a single request.
@@ -100,6 +116,14 @@ func WithRESTfulAPIServiceHeader(key, value string) RESTfulAPIServiceCallOption 
 func WithRESTfulAPIServiceCallContentType(contentType string) RESTfulAPIServiceCallOption {
 	return func(o *rESTfulAPIServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithRESTfulAPIServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithRESTfulAPIServiceDiscardUnknownFields.
+func WithRESTfulAPIServiceCallDiscardUnknownFields(discard bool) RESTfulAPIServiceCallOption {
+	return func(o *rESTfulAPIServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -213,9 +237,15 @@ func (c *rESTfulAPIServiceClient) ListResources(ctx context.Context, req *ListRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &ListResourcesResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -272,9 +302,15 @@ func (c *rESTfulAPIServiceClient) GetResource(ctx context.Context, req *GetResou
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Resource{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -333,9 +369,15 @@ func (c *rESTfulAPIServiceClient) GetNestedResource(ctx context.Context, req *Ge
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Resource{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -397,9 +439,15 @@ func (c *rESTfulAPIServiceClient) CreateResource(ctx context.Context, req *Creat
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Resource{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -462,9 +510,15 @@ func (c *rESTfulAPIServiceClient) UpdateResource(ctx context.Context, req *Updat
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Resource{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -527,9 +581,15 @@ func (c *rESTfulAPIServiceClient) PatchResource(ctx context.Context, req *PatchR
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Resource{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -586,9 +646,15 @@ func (c *rESTfulAPIServiceClient) DeleteResource(ctx context.Context, req *Delet
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &DeleteResourceResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -650,9 +716,15 @@ func (c *rESTfulAPIServiceClient) DefaultPostMethod(ctx context.Context, req *De
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &DefaultPostResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -720,9 +792,15 @@ func (c *rESTfulAPIServiceClient) SearchResources(ctx context.Context, req *Sear
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &ListResourcesResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -746,16 +824,18 @@ func (c *rESTfulAPIServiceClient) marshalRequest(req proto.Message, contentType 
 
 func (c *rESTfulAPIServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -763,22 +843,28 @@ func (c *rESTfulAPIServiceClient) handleErrorResponse(statusCode int, body []byt
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *rESTfulAPIServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *rESTfulAPIServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }
 
@@ -789,10 +875,11 @@ type BackwardCompatServiceClient interface {
 
 // backwardCompatServiceClient is the implementation of BackwardCompatServiceClient.
 type backwardCompatServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ BackwardCompatServiceClient = (*backwardCompatServiceClient)(nil)
@@ -825,13 +912,22 @@ func WithBackwardCompatServiceDefaultHeader(key, value string) BackwardCompatSer
 	}
 }
 
+// WithBackwardCompatServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithBackwardCompatServiceDiscardUnknownFields(discard bool) BackwardCompatServiceClientOption {
+	return func(c *backwardCompatServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // BackwardCompatServiceCallOption configures a single RPC call.
 type BackwardCompatServiceCallOption func(*backwardCompatServiceCallOptions)
 
 // backwardCompatServiceCallOptions holds options for a single RPC call.
 type backwardCompatServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithBackwardCompatServiceHeader adds a header to a single request.
@@ -848,6 +944,14 @@ func WithBackwardCompatServiceHeader(key, value string) BackwardCompatServiceCal
 func WithBackwardCompatServiceCallContentType(contentType string) BackwardCompatServiceCallOption {
 	return func(o *backwardCompatServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithBackwardCompatServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithBackwardCompatServiceDiscardUnknownFields.
+func WithBackwardCompatServiceCallDiscardUnknownFields(discard bool) BackwardCompatServiceCallOption {
+	return func(o *backwardCompatServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -922,9 +1026,15 @@ func (c *backwardCompatServiceClient) LegacyAction(ctx context.Context, req *Leg
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &LegacyResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -948,16 +1058,18 @@ func (c *backwardCompatServiceClient) marshalRequest(req proto.Message, contentT
 
 func (c *backwardCompatServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -965,21 +1077,27 @@ func (c *backwardCompatServiceClient) handleErrorResponse(statusCode int, body [
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *backwardCompatServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *backwardCompatServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/int64_encoding_client.pb.go
+++ b/internal/clientgen/testdata/golden/int64_encoding_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // Int64EncodingServiceClient is the client API for Int64EncodingService service.
 type Int64EncodingServiceClient interface {
 	GetInt64Test(ctx context.Context, req *GetInt64TestRequest, opts ...Int64EncodingServiceCallOption) (*Int64EncodingTest, error)
@@ -32,10 +38,11 @@ type Int64EncodingServiceClient interface {
 
 // int64EncodingServiceClient is the implementation of Int64EncodingServiceClient.
 type int64EncodingServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ Int64EncodingServiceClient = (*int64EncodingServiceClient)(nil)
@@ -68,13 +75,22 @@ func WithInt64EncodingServiceDefaultHeader(key, value string) Int64EncodingServi
 	}
 }
 
+// WithInt64EncodingServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithInt64EncodingServiceDiscardUnknownFields(discard bool) Int64EncodingServiceClientOption {
+	return func(c *int64EncodingServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // Int64EncodingServiceCallOption configures a single RPC call.
 type Int64EncodingServiceCallOption func(*int64EncodingServiceCallOptions)
 
 // int64EncodingServiceCallOptions holds options for a single RPC call.
 type int64EncodingServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithInt64EncodingServiceHeader adds a header to a single request.
@@ -91,6 +107,14 @@ func WithInt64EncodingServiceHeader(key, value string) Int64EncodingServiceCallO
 func WithInt64EncodingServiceCallContentType(contentType string) Int64EncodingServiceCallOption {
 	return func(o *int64EncodingServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithInt64EncodingServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithInt64EncodingServiceDiscardUnknownFields.
+func WithInt64EncodingServiceCallDiscardUnknownFields(discard bool) Int64EncodingServiceCallOption {
+	return func(o *int64EncodingServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -160,9 +184,15 @@ func (c *int64EncodingServiceClient) GetInt64Test(ctx context.Context, req *GetI
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &Int64EncodingTest{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -186,16 +216,18 @@ func (c *int64EncodingServiceClient) marshalRequest(req proto.Message, contentTy
 
 func (c *int64EncodingServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -203,21 +235,27 @@ func (c *int64EncodingServiceClient) handleErrorResponse(statusCode int, body []
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *int64EncodingServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *int64EncodingServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/int64_encoding_encoding.pb.go
+++ b/internal/clientgen/testdata/golden/int64_encoding_encoding.pb.go
@@ -94,9 +94,9 @@ func (x *Int64EncodingTest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Int64EncodingTest.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for Int64EncodingTest.
 // This method handles int64_encoding=NUMBER fields: number_int64, number_uint64, number_sint64, number_sfixed64, number_fixed64, repeated_number_int64, optional_number_int64, commented_number_int64
-func (x *Int64EncodingTest) UnmarshalJSON(data []byte) error {
+func (x *Int64EncodingTest) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -178,5 +178,10 @@ func (x *Int64EncodingTest) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Int64EncodingTest.
+func (x *Int64EncodingTest) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/int64_nested_encoding_client.pb.go
+++ b/internal/clientgen/testdata/golden/int64_nested_encoding_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // SensorServiceClient is the client API for SensorService service.
 type SensorServiceClient interface {
 	GetSensorReading(ctx context.Context, req *GetSensorRequest, opts ...SensorServiceCallOption) (*GetSensorReadingResponse, error)
@@ -33,10 +39,11 @@ type SensorServiceClient interface {
 
 // sensorServiceClient is the implementation of SensorServiceClient.
 type sensorServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ SensorServiceClient = (*sensorServiceClient)(nil)
@@ -69,13 +76,22 @@ func WithSensorServiceDefaultHeader(key, value string) SensorServiceClientOption
 	}
 }
 
+// WithSensorServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithSensorServiceDiscardUnknownFields(discard bool) SensorServiceClientOption {
+	return func(c *sensorServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // SensorServiceCallOption configures a single RPC call.
 type SensorServiceCallOption func(*sensorServiceCallOptions)
 
 // sensorServiceCallOptions holds options for a single RPC call.
 type sensorServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithSensorServiceHeader adds a header to a single request.
@@ -92,6 +108,14 @@ func WithSensorServiceHeader(key, value string) SensorServiceCallOption {
 func WithSensorServiceCallContentType(contentType string) SensorServiceCallOption {
 	return func(o *sensorServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithSensorServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithSensorServiceDiscardUnknownFields.
+func WithSensorServiceCallDiscardUnknownFields(discard bool) SensorServiceCallOption {
+	return func(o *sensorServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -161,9 +185,15 @@ func (c *sensorServiceClient) GetSensorReading(ctx context.Context, req *GetSens
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &GetSensorReadingResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -220,9 +250,15 @@ func (c *sensorServiceClient) GetMultiSensor(ctx context.Context, req *GetSensor
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &GetMultiSensorResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -246,16 +282,18 @@ func (c *sensorServiceClient) marshalRequest(req proto.Message, contentType stri
 
 func (c *sensorServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -263,21 +301,27 @@ func (c *sensorServiceClient) handleErrorResponse(statusCode int, body []byte, c
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *sensorServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *sensorServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/int64_nested_encoding_encoding.pb.go
+++ b/internal/clientgen/testdata/golden/int64_nested_encoding_encoding.pb.go
@@ -46,9 +46,9 @@ func (x *SensorReading) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for SensorReading.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for SensorReading.
 // This method handles int64_encoding=NUMBER fields: timestamp_ms, values
-func (x *SensorReading) UnmarshalJSON(data []byte) error {
+func (x *SensorReading) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -82,7 +82,12 @@ func (x *SensorReading) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for SensorReading.
+func (x *SensorReading) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSON implements json.Marshaler for GetSensorReadingResponse.
@@ -115,18 +120,24 @@ func (x *GetSensorReadingResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for GetSensorReadingResponse.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for GetSensorReadingResponse.
 // This method handles nested messages that have int64_encoding=NUMBER fields: reading
-func (x *GetSensorReadingResponse) UnmarshalJSON(data []byte) error {
+func (x *GetSensorReadingResponse) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	// Handle "reading" using its custom UnmarshalJSON
+	// Handle "reading" using its custom unmarshaler
 	if rawVal, ok := raw["reading"]; ok {
 		inner := &SensorReading{}
-		if err := json.Unmarshal(rawVal, inner); err != nil {
+		if u, ok := any(inner).(interface {
+			UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+		}); ok {
+			if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {
+				return err
+			}
+		} else if err := json.Unmarshal(rawVal, inner); err != nil {
 			return err
 		}
 		innerJSON, err := protojson.Marshal(inner)
@@ -141,7 +152,12 @@ func (x *GetSensorReadingResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for GetSensorReadingResponse.
+func (x *GetSensorReadingResponse) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSON implements json.Marshaler for GetMultiSensorResponse.
@@ -182,18 +198,24 @@ func (x *GetMultiSensorResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for GetMultiSensorResponse.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for GetMultiSensorResponse.
 // This method handles nested messages that have int64_encoding=NUMBER fields: primary, secondary
-func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
+func (x *GetMultiSensorResponse) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	// Handle "primary" using its custom UnmarshalJSON
+	// Handle "primary" using its custom unmarshaler
 	if rawVal, ok := raw["primary"]; ok {
 		inner := &SensorReading{}
-		if err := json.Unmarshal(rawVal, inner); err != nil {
+		if u, ok := any(inner).(interface {
+			UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+		}); ok {
+			if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {
+				return err
+			}
+		} else if err := json.Unmarshal(rawVal, inner); err != nil {
 			return err
 		}
 		innerJSON, err := protojson.Marshal(inner)
@@ -203,10 +225,16 @@ func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
 		raw["primary"] = innerJSON
 	}
 
-	// Handle "secondary" using its custom UnmarshalJSON
+	// Handle "secondary" using its custom unmarshaler
 	if rawVal, ok := raw["secondary"]; ok {
 		inner := &SensorReading{}
-		if err := json.Unmarshal(rawVal, inner); err != nil {
+		if u, ok := any(inner).(interface {
+			UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+		}); ok {
+			if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {
+				return err
+			}
+		} else if err := json.Unmarshal(rawVal, inner); err != nil {
 			return err
 		}
 		innerJSON, err := protojson.Marshal(inner)
@@ -221,5 +249,10 @@ func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for GetMultiSensorResponse.
+func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/nullable_client.pb.go
+++ b/internal/clientgen/testdata/golden/nullable_client.pb.go
@@ -26,6 +26,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // NullableServiceClient is the client API for NullableService service.
 type NullableServiceClient interface {
 	GetUser(ctx context.Context, req *GetUserRequest, opts ...NullableServiceCallOption) (*User, error)
@@ -34,10 +40,11 @@ type NullableServiceClient interface {
 
 // nullableServiceClient is the implementation of NullableServiceClient.
 type nullableServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ NullableServiceClient = (*nullableServiceClient)(nil)
@@ -70,13 +77,22 @@ func WithNullableServiceDefaultHeader(key, value string) NullableServiceClientOp
 	}
 }
 
+// WithNullableServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithNullableServiceDiscardUnknownFields(discard bool) NullableServiceClientOption {
+	return func(c *nullableServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // NullableServiceCallOption configures a single RPC call.
 type NullableServiceCallOption func(*nullableServiceCallOptions)
 
 // nullableServiceCallOptions holds options for a single RPC call.
 type nullableServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithNullableServiceHeader adds a header to a single request.
@@ -93,6 +109,14 @@ func WithNullableServiceHeader(key, value string) NullableServiceCallOption {
 func WithNullableServiceCallContentType(contentType string) NullableServiceCallOption {
 	return func(o *nullableServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithNullableServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithNullableServiceDiscardUnknownFields.
+func WithNullableServiceCallDiscardUnknownFields(discard bool) NullableServiceCallOption {
+	return func(o *nullableServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -162,9 +186,15 @@ func (c *nullableServiceClient) GetUser(ctx context.Context, req *GetUserRequest
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &User{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -227,9 +257,15 @@ func (c *nullableServiceClient) UpdateUser(ctx context.Context, req *UpdateUserR
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &User{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -253,16 +289,18 @@ func (c *nullableServiceClient) marshalRequest(req proto.Message, contentType st
 
 func (c *nullableServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -270,21 +308,27 @@ func (c *nullableServiceClient) handleErrorResponse(statusCode int, body []byte,
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *nullableServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *nullableServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/nullable_nullable.pb.go
+++ b/internal/clientgen/testdata/golden/nullable_nullable.pb.go
@@ -49,9 +49,9 @@ func (x *User) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for User.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for User.
 // This method handles nullable fields: middle_name, age, is_verified
-func (x *User) UnmarshalJSON(data []byte) error {
+func (x *User) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// Parse to check for explicit null values on nullable fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -82,5 +82,10 @@ func (x *User) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for User.
+func (x *User) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/oneof_discriminator_client.pb.go
+++ b/internal/clientgen/testdata/golden/oneof_discriminator_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // OneofDiscriminatorServiceClient is the client API for OneofDiscriminatorService service.
 type OneofDiscriminatorServiceClient interface {
 	TestFlattenedEvent(ctx context.Context, req *FlattenedEvent, opts ...OneofDiscriminatorServiceCallOption) (*FlattenedEvent, error)
@@ -34,10 +40,11 @@ type OneofDiscriminatorServiceClient interface {
 
 // oneofDiscriminatorServiceClient is the implementation of OneofDiscriminatorServiceClient.
 type oneofDiscriminatorServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ OneofDiscriminatorServiceClient = (*oneofDiscriminatorServiceClient)(nil)
@@ -70,13 +77,22 @@ func WithOneofDiscriminatorServiceDefaultHeader(key, value string) OneofDiscrimi
 	}
 }
 
+// WithOneofDiscriminatorServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithOneofDiscriminatorServiceDiscardUnknownFields(discard bool) OneofDiscriminatorServiceClientOption {
+	return func(c *oneofDiscriminatorServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // OneofDiscriminatorServiceCallOption configures a single RPC call.
 type OneofDiscriminatorServiceCallOption func(*oneofDiscriminatorServiceCallOptions)
 
 // oneofDiscriminatorServiceCallOptions holds options for a single RPC call.
 type oneofDiscriminatorServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithOneofDiscriminatorServiceHeader adds a header to a single request.
@@ -93,6 +109,14 @@ func WithOneofDiscriminatorServiceHeader(key, value string) OneofDiscriminatorSe
 func WithOneofDiscriminatorServiceCallContentType(contentType string) OneofDiscriminatorServiceCallOption {
 	return func(o *oneofDiscriminatorServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithOneofDiscriminatorServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithOneofDiscriminatorServiceDiscardUnknownFields.
+func WithOneofDiscriminatorServiceCallDiscardUnknownFields(discard bool) OneofDiscriminatorServiceCallOption {
+	return func(o *oneofDiscriminatorServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -167,9 +191,15 @@ func (c *oneofDiscriminatorServiceClient) TestFlattenedEvent(ctx context.Context
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &FlattenedEvent{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -231,9 +261,15 @@ func (c *oneofDiscriminatorServiceClient) TestNestedEvent(ctx context.Context, r
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &NestedEvent{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -295,9 +331,15 @@ func (c *oneofDiscriminatorServiceClient) TestPlainEvent(ctx context.Context, re
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &PlainEvent{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -321,16 +363,18 @@ func (c *oneofDiscriminatorServiceClient) marshalRequest(req proto.Message, cont
 
 func (c *oneofDiscriminatorServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -338,21 +382,27 @@ func (c *oneofDiscriminatorServiceClient) handleErrorResponse(statusCode int, bo
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *oneofDiscriminatorServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *oneofDiscriminatorServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/oneof_discriminator_oneof_discriminator.pb.go
+++ b/internal/clientgen/testdata/golden/oneof_discriminator_oneof_discriminator.pb.go
@@ -70,9 +70,9 @@ func (x *FlattenedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for FlattenedEvent.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for FlattenedEvent.
 // This method handles oneof discriminator fields: content
-func (x *FlattenedEvent) UnmarshalJSON(data []byte) error {
+func (x *FlattenedEvent) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// Parse into a map to read discriminator fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -96,7 +96,13 @@ func (x *FlattenedEvent) UnmarshalJSON(data []byte) error {
 			}
 			variantData, _ := json.Marshal(variantMap)
 			variant := &TextContent{}
-			if err := json.Unmarshal(variantData, variant); err != nil {
+			if u, ok := any(variant).(interface {
+				UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+			}); ok {
+				if err := u.UnmarshalJSONSebuf(variantData, opts); err != nil {
+					return fmt.Errorf("failed to unmarshal variant %s: %%w", "Text", err)
+				}
+			} else if err := json.Unmarshal(variantData, variant); err != nil {
 				return fmt.Errorf("failed to unmarshal variant %s: %%w", "Text", err)
 			}
 			x.Content = &FlattenedEvent_Text{Text: variant}
@@ -118,7 +124,13 @@ func (x *FlattenedEvent) UnmarshalJSON(data []byte) error {
 			}
 			variantData, _ := json.Marshal(variantMap)
 			variant := &ImageContent{}
-			if err := json.Unmarshal(variantData, variant); err != nil {
+			if u, ok := any(variant).(interface {
+				UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+			}); ok {
+				if err := u.UnmarshalJSONSebuf(variantData, opts); err != nil {
+					return fmt.Errorf("failed to unmarshal variant %s: %%w", "Image", err)
+				}
+			} else if err := json.Unmarshal(variantData, variant); err != nil {
 				return fmt.Errorf("failed to unmarshal variant %s: %%w", "Image", err)
 			}
 			x.Content = &FlattenedEvent_Image{Image: variant}
@@ -135,7 +147,12 @@ func (x *FlattenedEvent) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for FlattenedEvent.
+func (x *FlattenedEvent) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSON implements json.Marshaler for NestedEvent.
@@ -172,9 +189,9 @@ func (x *NestedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for NestedEvent.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for NestedEvent.
 // This method handles oneof discriminator fields: content
-func (x *NestedEvent) UnmarshalJSON(data []byte) error {
+func (x *NestedEvent) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// Parse into a map to read discriminator fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -190,28 +207,46 @@ func (x *NestedEvent) UnmarshalJSON(data []byte) error {
 
 		switch disc {
 		case "text":
-			// Non-flattened unmarshal: use json.Unmarshal for child UnmarshalJSON support
+			// Non-flattened unmarshal: forward opts to child's UnmarshalJSONSebuf if available
 			if variantRaw, exists := raw["text"]; exists {
 				variant := &TextContent{}
-				if err := json.Unmarshal(variantRaw, variant); err != nil {
+				if u, ok := any(variant).(interface {
+					UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+				}); ok {
+					if err := u.UnmarshalJSONSebuf(variantRaw, opts); err != nil {
+						return fmt.Errorf("failed to unmarshal variant %s: %%w", "Text", err)
+					}
+				} else if err := json.Unmarshal(variantRaw, variant); err != nil {
 					return fmt.Errorf("failed to unmarshal variant %s: %%w", "Text", err)
 				}
 				x.Content = &NestedEvent_Text{Text: variant}
 			}
 		case "image":
-			// Non-flattened unmarshal: use json.Unmarshal for child UnmarshalJSON support
+			// Non-flattened unmarshal: forward opts to child's UnmarshalJSONSebuf if available
 			if variantRaw, exists := raw["image"]; exists {
 				variant := &ImageContent{}
-				if err := json.Unmarshal(variantRaw, variant); err != nil {
+				if u, ok := any(variant).(interface {
+					UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+				}); ok {
+					if err := u.UnmarshalJSONSebuf(variantRaw, opts); err != nil {
+						return fmt.Errorf("failed to unmarshal variant %s: %%w", "Image", err)
+					}
+				} else if err := json.Unmarshal(variantRaw, variant); err != nil {
 					return fmt.Errorf("failed to unmarshal variant %s: %%w", "Image", err)
 				}
 				x.Content = &NestedEvent_Image{Image: variant}
 			}
 		case "vid":
-			// Non-flattened unmarshal: use json.Unmarshal for child UnmarshalJSON support
+			// Non-flattened unmarshal: forward opts to child's UnmarshalJSONSebuf if available
 			if variantRaw, exists := raw["video"]; exists {
 				variant := &VideoContent{}
-				if err := json.Unmarshal(variantRaw, variant); err != nil {
+				if u, ok := any(variant).(interface {
+					UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+				}); ok {
+					if err := u.UnmarshalJSONSebuf(variantRaw, opts); err != nil {
+						return fmt.Errorf("failed to unmarshal variant %s: %%w", "Video", err)
+					}
+				} else if err := json.Unmarshal(variantRaw, variant); err != nil {
 					return fmt.Errorf("failed to unmarshal variant %s: %%w", "Video", err)
 				}
 				x.Content = &NestedEvent_Video{Video: variant}
@@ -228,5 +263,10 @@ func (x *NestedEvent) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for NestedEvent.
+func (x *NestedEvent) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/query_params_client.pb.go
+++ b/internal/clientgen/testdata/golden/query_params_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // QueryParamServiceClient is the client API for QueryParamService service.
 type QueryParamServiceClient interface {
 	SearchWithTypes(ctx context.Context, req *SearchWithTypesRequest, opts ...QueryParamServiceCallOption) (*SearchResponse, error)
@@ -37,10 +43,11 @@ type QueryParamServiceClient interface {
 
 // queryParamServiceClient is the implementation of QueryParamServiceClient.
 type queryParamServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ QueryParamServiceClient = (*queryParamServiceClient)(nil)
@@ -73,13 +80,22 @@ func WithQueryParamServiceDefaultHeader(key, value string) QueryParamServiceClie
 	}
 }
 
+// WithQueryParamServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithQueryParamServiceDiscardUnknownFields(discard bool) QueryParamServiceClientOption {
+	return func(c *queryParamServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // QueryParamServiceCallOption configures a single RPC call.
 type QueryParamServiceCallOption func(*queryParamServiceCallOptions)
 
 // queryParamServiceCallOptions holds options for a single RPC call.
 type queryParamServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithQueryParamServiceHeader adds a header to a single request.
@@ -96,6 +112,14 @@ func WithQueryParamServiceHeader(key, value string) QueryParamServiceCallOption 
 func WithQueryParamServiceCallContentType(contentType string) QueryParamServiceCallOption {
 	return func(o *queryParamServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithQueryParamServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithQueryParamServiceDiscardUnknownFields.
+func WithQueryParamServiceCallDiscardUnknownFields(discard bool) QueryParamServiceCallOption {
+	return func(o *queryParamServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -194,9 +218,15 @@ func (c *queryParamServiceClient) SearchWithTypes(ctx context.Context, req *Sear
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SearchResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -267,9 +297,15 @@ func (c *queryParamServiceClient) SearchRequired(ctx context.Context, req *Searc
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SearchResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -346,9 +382,15 @@ func (c *queryParamServiceClient) SearchCustomNames(ctx context.Context, req *Se
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SearchResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -417,9 +459,15 @@ func (c *queryParamServiceClient) GetWithFilters(ctx context.Context, req *GetWi
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SearchResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -496,9 +544,15 @@ func (c *queryParamServiceClient) SearchAdvanced(ctx context.Context, req *Searc
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SearchResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -554,9 +608,15 @@ func (c *queryParamServiceClient) GetDefaults(ctx context.Context, req *EmptyReq
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &SearchResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -580,16 +640,18 @@ func (c *queryParamServiceClient) marshalRequest(req proto.Message, contentType 
 
 func (c *queryParamServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -597,21 +659,27 @@ func (c *queryParamServiceClient) handleErrorResponse(statusCode int, body []byt
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *queryParamServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *queryParamServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/sse_client.pb.go
+++ b/internal/clientgen/testdata/golden/sse_client.pb.go
@@ -26,6 +26,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // SSEServiceClient is the client API for SSEService service.
 type SSEServiceClient interface {
 	GetStatus(ctx context.Context, req *GetStatusRequest, opts ...SSEServiceCallOption) (*StatusResponse, error)
@@ -36,10 +42,11 @@ type SSEServiceClient interface {
 
 // sSEServiceClient is the implementation of SSEServiceClient.
 type sSEServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ SSEServiceClient = (*sSEServiceClient)(nil)
@@ -72,13 +79,22 @@ func WithSSEServiceDefaultHeader(key, value string) SSEServiceClientOption {
 	}
 }
 
+// WithSSEServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithSSEServiceDiscardUnknownFields(discard bool) SSEServiceClientOption {
+	return func(c *sSEServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // SSEServiceCallOption configures a single RPC call.
 type SSEServiceCallOption func(*sSEServiceCallOptions)
 
 // sSEServiceCallOptions holds options for a single RPC call.
 type sSEServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithSSEServiceHeader adds a header to a single request.
@@ -95,6 +111,14 @@ func WithSSEServiceHeader(key, value string) SSEServiceCallOption {
 func WithSSEServiceCallContentType(contentType string) SSEServiceCallOption {
 	return func(o *sSEServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithSSEServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithSSEServiceDiscardUnknownFields.
+func WithSSEServiceCallDiscardUnknownFields(discard bool) SSEServiceCallOption {
+	return func(o *sSEServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -116,9 +140,10 @@ func NewSSEServiceClient(baseURL string, opts ...SSEServiceClientOption) SSEServ
 
 // SSEServiceEventStream reads Server-Sent Events from a streaming endpoint.
 type SSEServiceEventStream[T proto.Message] struct {
-	resp   *http.Response
-	reader *bufio.Reader
-	err    error
+	resp                 *http.Response
+	reader               *bufio.Reader
+	err                  error
+	discardUnknownFields bool
 }
 
 // Next reads the next event from the stream.
@@ -137,8 +162,17 @@ func (s *SSEServiceEventStream[T]) Next(event T) bool {
 			continue
 		}
 		data := strings.TrimPrefix(line, "data: ")
-		if err := protojson.Unmarshal([]byte(data), event); err != nil {
-			s.err = fmt.Errorf("failed to unmarshal SSE event: %w", err)
+		opts := protojson.UnmarshalOptions{DiscardUnknown: s.discardUnknownFields}
+		var unmarshalErr error
+		if u, ok := any(event).(sebufUnmarshaler); ok {
+			unmarshalErr = u.UnmarshalJSONSebuf([]byte(data), opts)
+		} else if u, ok := any(event).(json.Unmarshaler); ok {
+			unmarshalErr = u.UnmarshalJSON([]byte(data))
+		} else {
+			unmarshalErr = opts.Unmarshal([]byte(data), event)
+		}
+		if unmarshalErr != nil {
+			s.err = fmt.Errorf("failed to unmarshal SSE event: %w", unmarshalErr)
 			return false
 		}
 		return true
@@ -204,9 +238,15 @@ func (c *sSEServiceClient) GetStatus(ctx context.Context, req *GetStatusRequest,
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &StatusResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -261,9 +301,15 @@ func (c *sSEServiceClient) StreamEvents(ctx context.Context, req *StreamEventsRe
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	return &SSEServiceEventStream[*Event]{
-		resp:   resp,
-		reader: bufio.NewReader(resp.Body),
+		resp:                 resp,
+		reader:               bufio.NewReader(resp.Body),
+		discardUnknownFields: discardUnknown,
 	}, nil
 }
 
@@ -316,9 +362,15 @@ func (c *sSEServiceClient) StreamResourceEvents(ctx context.Context, req *Stream
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	return &SSEServiceEventStream[*ResourceEvent]{
-		resp:   resp,
-		reader: bufio.NewReader(resp.Body),
+		resp:                 resp,
+		reader:               bufio.NewReader(resp.Body),
+		discardUnknownFields: discardUnknown,
 	}, nil
 }
 
@@ -382,9 +434,15 @@ func (c *sSEServiceClient) StreamFilteredEvents(ctx context.Context, req *Stream
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	return &SSEServiceEventStream[*Event]{
-		resp:   resp,
-		reader: bufio.NewReader(resp.Body),
+		resp:                 resp,
+		reader:               bufio.NewReader(resp.Body),
+		discardUnknownFields: discardUnknown,
 	}, nil
 }
 
@@ -405,16 +463,18 @@ func (c *sSEServiceClient) marshalRequest(req proto.Message, contentType string)
 
 func (c *sSEServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -422,21 +482,27 @@ func (c *sSEServiceClient) handleErrorResponse(statusCode int, body []byte, cont
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *sSEServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *sSEServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/timestamp_format_client.pb.go
+++ b/internal/clientgen/testdata/golden/timestamp_format_client.pb.go
@@ -26,6 +26,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // TimestampFormatServiceClient is the client API for TimestampFormatService service.
 type TimestampFormatServiceClient interface {
 	CreateTimestampFormat(ctx context.Context, req *TimestampFormatTest, opts ...TimestampFormatServiceCallOption) (*TimestampFormatTest, error)
@@ -34,10 +40,11 @@ type TimestampFormatServiceClient interface {
 
 // timestampFormatServiceClient is the implementation of TimestampFormatServiceClient.
 type timestampFormatServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ TimestampFormatServiceClient = (*timestampFormatServiceClient)(nil)
@@ -70,13 +77,22 @@ func WithTimestampFormatServiceDefaultHeader(key, value string) TimestampFormatS
 	}
 }
 
+// WithTimestampFormatServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithTimestampFormatServiceDiscardUnknownFields(discard bool) TimestampFormatServiceClientOption {
+	return func(c *timestampFormatServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // TimestampFormatServiceCallOption configures a single RPC call.
 type TimestampFormatServiceCallOption func(*timestampFormatServiceCallOptions)
 
 // timestampFormatServiceCallOptions holds options for a single RPC call.
 type timestampFormatServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithTimestampFormatServiceHeader adds a header to a single request.
@@ -93,6 +109,14 @@ func WithTimestampFormatServiceHeader(key, value string) TimestampFormatServiceC
 func WithTimestampFormatServiceCallContentType(contentType string) TimestampFormatServiceCallOption {
 	return func(o *timestampFormatServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithTimestampFormatServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithTimestampFormatServiceDiscardUnknownFields.
+func WithTimestampFormatServiceCallDiscardUnknownFields(discard bool) TimestampFormatServiceCallOption {
+	return func(o *timestampFormatServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -167,9 +191,15 @@ func (c *timestampFormatServiceClient) CreateTimestampFormat(ctx context.Context
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &TimestampFormatTest{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -226,9 +256,15 @@ func (c *timestampFormatServiceClient) GetTimestampFormat(ctx context.Context, r
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &TimestampFormatTest{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -252,16 +288,18 @@ func (c *timestampFormatServiceClient) marshalRequest(req proto.Message, content
 
 func (c *timestampFormatServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -269,21 +307,27 @@ func (c *timestampFormatServiceClient) handleErrorResponse(statusCode int, body 
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *timestampFormatServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *timestampFormatServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/testdata/golden/timestamp_format_timestamp_format.pb.go
+++ b/internal/clientgen/testdata/golden/timestamp_format_timestamp_format.pb.go
@@ -50,9 +50,9 @@ func (x *TimestampFormatTest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for TimestampFormatTest.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for TimestampFormatTest.
 // This method handles timestamp_format fields: unix_seconds_ts, unix_millis_ts, date_ts
-func (x *TimestampFormatTest) UnmarshalJSON(data []byte) error {
+func (x *TimestampFormatTest) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// Parse the raw JSON to extract timestamp format fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -95,5 +95,10 @@ func (x *TimestampFormatTest) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for TimestampFormatTest.
+func (x *TimestampFormatTest) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/clientgen/testdata/golden/unwrap_client.pb.go
+++ b/internal/clientgen/testdata/golden/unwrap_client.pb.go
@@ -25,6 +25,12 @@ const (
 	ContentTypeProto = "application/x-protobuf"
 )
 
+// sebufUnmarshaler is implemented by generated messages with custom JSON unmarshaling.
+// It allows passing protojson.UnmarshalOptions (e.g. DiscardUnknown) through custom unmarshalers.
+type sebufUnmarshaler interface {
+	UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
+}
+
 // OptionDataServiceClient is the client API for OptionDataService service.
 type OptionDataServiceClient interface {
 	GetOptionBars(ctx context.Context, req *GetOptionBarsRequest, opts ...OptionDataServiceCallOption) (*GetOptionBarsResponse, error)
@@ -32,10 +38,11 @@ type OptionDataServiceClient interface {
 
 // optionDataServiceClient is the implementation of OptionDataServiceClient.
 type optionDataServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ OptionDataServiceClient = (*optionDataServiceClient)(nil)
@@ -68,13 +75,22 @@ func WithOptionDataServiceDefaultHeader(key, value string) OptionDataServiceClie
 	}
 }
 
+// WithOptionDataServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithOptionDataServiceDiscardUnknownFields(discard bool) OptionDataServiceClientOption {
+	return func(c *optionDataServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // OptionDataServiceCallOption configures a single RPC call.
 type OptionDataServiceCallOption func(*optionDataServiceCallOptions)
 
 // optionDataServiceCallOptions holds options for a single RPC call.
 type optionDataServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithOptionDataServiceHeader adds a header to a single request.
@@ -91,6 +107,14 @@ func WithOptionDataServiceHeader(key, value string) OptionDataServiceCallOption 
 func WithOptionDataServiceCallContentType(contentType string) OptionDataServiceCallOption {
 	return func(o *optionDataServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithOptionDataServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithOptionDataServiceDiscardUnknownFields.
+func WithOptionDataServiceCallDiscardUnknownFields(discard bool) OptionDataServiceCallOption {
+	return func(o *optionDataServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -165,9 +189,15 @@ func (c *optionDataServiceClient) GetOptionBars(ctx context.Context, req *GetOpt
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &GetOptionBarsResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -191,16 +221,18 @@ func (c *optionDataServiceClient) marshalRequest(req proto.Message, contentType 
 
 func (c *optionDataServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -208,22 +240,28 @@ func (c *optionDataServiceClient) handleErrorResponse(statusCode int, body []byt
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *optionDataServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *optionDataServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }
 
@@ -237,10 +275,11 @@ type UnwrapServiceClient interface {
 
 // unwrapServiceClient is the implementation of UnwrapServiceClient.
 type unwrapServiceClient struct {
-	baseURL        string
-	httpClient     *http.Client
-	contentType    string
-	defaultHeaders map[string]string
+	baseURL              string
+	httpClient           *http.Client
+	contentType          string
+	defaultHeaders       map[string]string
+	discardUnknownFields bool
 }
 
 var _ UnwrapServiceClient = (*unwrapServiceClient)(nil)
@@ -273,13 +312,22 @@ func WithUnwrapServiceDefaultHeader(key, value string) UnwrapServiceClientOption
 	}
 }
 
+// WithUnwrapServiceDiscardUnknownFields sets whether to discard unknown fields in JSON responses.
+// When true, unknown fields are silently ignored instead of causing unmarshal errors.
+func WithUnwrapServiceDiscardUnknownFields(discard bool) UnwrapServiceClientOption {
+	return func(c *unwrapServiceClient) {
+		c.discardUnknownFields = discard
+	}
+}
+
 // UnwrapServiceCallOption configures a single RPC call.
 type UnwrapServiceCallOption func(*unwrapServiceCallOptions)
 
 // unwrapServiceCallOptions holds options for a single RPC call.
 type unwrapServiceCallOptions struct {
-	headers     map[string]string
-	contentType string
+	headers              map[string]string
+	contentType          string
+	discardUnknownFields *bool
 }
 
 // WithUnwrapServiceHeader adds a header to a single request.
@@ -296,6 +344,14 @@ func WithUnwrapServiceHeader(key, value string) UnwrapServiceCallOption {
 func WithUnwrapServiceCallContentType(contentType string) UnwrapServiceCallOption {
 	return func(o *unwrapServiceCallOptions) {
 		o.contentType = contentType
+	}
+}
+
+// WithUnwrapServiceCallDiscardUnknownFields sets whether to discard unknown fields for a single request.
+// Overrides the client-level setting from WithUnwrapServiceDiscardUnknownFields.
+func WithUnwrapServiceCallDiscardUnknownFields(discard bool) UnwrapServiceCallOption {
+	return func(o *unwrapServiceCallOptions) {
+		o.discardUnknownFields = &discard
 	}
 }
 
@@ -370,9 +426,15 @@ func (c *unwrapServiceClient) GetOptionBars(ctx context.Context, req *GetOptionB
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &GetOptionBarsResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -434,9 +496,15 @@ func (c *unwrapServiceClient) GetRootMap(ctx context.Context, req *GetOptionBars
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &RootMapResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -498,9 +566,15 @@ func (c *unwrapServiceClient) GetRootRepeated(ctx context.Context, req *GetOptio
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &RootRepeatedResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -562,9 +636,15 @@ func (c *unwrapServiceClient) GetRootMapWithValueUnwrap(ctx context.Context, req
 		return nil, c.handleErrorResponse(resp.StatusCode, respBody, contentType)
 	}
 
+	// Resolve discardUnknownFields: per-call option overrides client default
+	discardUnknown := c.discardUnknownFields
+	if callOpts.discardUnknownFields != nil {
+		discardUnknown = *callOpts.discardUnknownFields
+	}
+
 	// Unmarshal response
 	result := &RootMapWithValueUnwrapResponse{}
-	if err := c.unmarshalResponse(respBody, result, contentType); err != nil {
+	if err := c.unmarshalResponse(respBody, result, contentType, discardUnknown); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -588,16 +668,18 @@ func (c *unwrapServiceClient) marshalRequest(req proto.Message, contentType stri
 
 func (c *unwrapServiceClient) handleErrorResponse(statusCode int, body []byte, contentType string) error {
 	// Try to parse as ValidationError first (for 400 errors)
+	// Always use strict mode (false) for error parsing to avoid loose JSON
+	// falsely matching ValidationError or Error types.
 	if statusCode == http.StatusBadRequest {
 		validationErr := &sebufhttp.ValidationError{}
-		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType); unmarshalErr == nil {
+		if unmarshalErr := c.unmarshalResponse(body, validationErr, contentType, false); unmarshalErr == nil {
 			return validationErr
 		}
 	}
 
 	// Try to parse as generic Error
 	genericErr := &sebufhttp.Error{}
-	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType); unmarshalErr == nil {
+	if unmarshalErr := c.unmarshalResponse(body, genericErr, contentType, false); unmarshalErr == nil {
 		return genericErr
 	}
 
@@ -605,21 +687,27 @@ func (c *unwrapServiceClient) handleErrorResponse(statusCode int, body []byte, c
 	return fmt.Errorf("request failed with status %d: %s", statusCode, string(body))
 }
 
-func (c *unwrapServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string) error {
+func (c *unwrapServiceClient) unmarshalResponse(body []byte, msg proto.Message, contentType string, discardUnknown bool) error {
 	if len(body) == 0 {
 		return nil
 	}
 
+	opts := protojson.UnmarshalOptions{DiscardUnknown: discardUnknown}
+
 	switch contentType {
 	case ContentTypeJSON:
-		// Check for custom JSON unmarshaler (unwrap support)
-		if unmarshaler, ok := msg.(json.Unmarshaler); ok {
-			return unmarshaler.UnmarshalJSON(body)
+		// Check for sebuf-generated custom unmarshaler (passes options through)
+		if u, ok := msg.(sebufUnmarshaler); ok {
+			return u.UnmarshalJSONSebuf(body, opts)
 		}
-		return protojson.Unmarshal(body, msg)
+		// Check for third-party json.Unmarshaler (best effort, cannot pass options)
+		if u, ok := msg.(json.Unmarshaler); ok {
+			return u.UnmarshalJSON(body)
+		}
+		return opts.Unmarshal(body, msg)
 	case ContentTypeProto:
 		return proto.Unmarshal(body, msg)
 	default:
-		return protojson.Unmarshal(body, msg)
+		return opts.Unmarshal(body, msg)
 	}
 }

--- a/internal/clientgen/timestamp_format.go
+++ b/internal/clientgen/timestamp_format.go
@@ -206,9 +206,9 @@ func (g *Generator) generateTimestampFormatUnmarshalJSON(gf *protogen.GeneratedF
 		fieldNames = append(fieldNames, string(f.Field.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles timestamp_format fields: ", strings.Join(fieldNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("// Parse the raw JSON to extract timestamp format fields")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
@@ -227,7 +227,14 @@ func (g *Generator) generateTimestampFormatUnmarshalJSON(gf *protogen.GeneratedF
 	gf.P("}")
 	gf.P()
 	gf.P("// Use protojson to unmarshal the rest")
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }


### PR DESCRIPTION
## Problem

The previous `DiscardUnknownFields` implementation was silently bypassed by every custom unmarshaler (int64 encoding, nullable, flatten, oneof discriminator, timestamp, bytes, empty_behavior). The `json.Unmarshaler` interface has no way to receive options, so `unmarshalResponse` called `UnmarshalJSON(body)` with no discard flag — the feature only worked on plain proto messages.

## Solution

Introduce a `sebufUnmarshaler` interface that passes `protojson.UnmarshalOptions` directly:

```go
type sebufUnmarshaler interface {
    UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error
}
```

- All 8 custom unmarshaler generators now emit `UnmarshalJSONSebuf` (receives opts) + a thin `UnmarshalJSON` wrapper (backward-compatible with `encoding/json`)
- `unmarshalResponse` checks `sebufUnmarshaler` first, then `json.Unmarshaler` (third-party fallback), then `opts.Unmarshal`
- SSE `EventStream.Next` uses the same dispatch pattern
- Wrapper/flatten/oneof generators forward opts to nested children
- `handleErrorResponse` always passes `false` (strict) to avoid false-matching error types

## API (unchanged from previous iteration)

```go
// Client-level
client := NewQuoteServiceClient(url, WithQuoteServiceDiscardUnknownFields(true))

// Per-call override (pointer semantics — per-call wins when set)
resp, _ := client.GetQuote(ctx, req, WithQuoteServiceCallDiscardUnknownFields(false))
```

## Tests

- **18 golden pattern assertions** — verify `UnmarshalJSONSebuf` on all annotated messages, `sebufUnmarshaler` interface in client files, opts forwarding in wrapper/flatten/oneof, error path strict mode, SSE support
- **12 httptest integration tests** — default strict rejects unknowns, client-level discard, per-call precedence (`*bool` semantics including client=true+call=false), error response path, proto content type no-op, empty body
- **15 golden file comparisons** — all existing test services regenerated

Closes #153