### PR TITLE
fix(httpgen): emit UnmarshalJSONSebuf for int64 NUMBER fields

### DIFF
--- a/internal/httpgen/encoding.go
+++ b/internal/httpgen/encoding.go
@@ -325,9 +325,9 @@ func (g *Generator) generateInt64UnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 		numberFieldNames = append(numberFieldNames, string(f.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P("// This method handles int64_encoding=NUMBER fields: ", strings.Join(numberFieldNames, ", "))
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("// First, parse the raw JSON to extract NUMBER-encoded fields")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
@@ -347,7 +347,14 @@ func (g *Generator) generateInt64UnmarshalJSON(gf *protogen.GeneratedFile, ctx *
 	gf.P("}")
 	gf.P()
 	gf.P("// Use protojson to unmarshal the rest")
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }
@@ -529,8 +536,9 @@ func (g *Generator) generateWrapperMarshalJSON(gf *protogen.GeneratedFile, ctx *
 	gf.P()
 }
 
-// generateWrapperUnmarshalJSON generates an UnmarshalJSON that delegates nested
-// message parsing to their custom UnmarshalJSON, then converts back for protojson.
+// generateWrapperUnmarshalJSON generates an UnmarshalJSONSebuf that delegates nested
+// message parsing via the sebufUnmarshaler interface (propagating opts), then converts
+// back for protojson. Also emits a backward-compatible UnmarshalJSON wrapper.
 func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx *Int64WrapperContext) {
 	msgName := ctx.Message.GoIdent.GoName
 
@@ -539,12 +547,12 @@ func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 		nestedFieldNames = append(nestedFieldNames, string(f.Desc.Name()))
 	}
 
-	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("// UnmarshalJSONSebuf implements sebufUnmarshaler for ", msgName, ".")
 	gf.P(
 		"// This method handles nested messages that have int64_encoding=NUMBER fields: ",
 		strings.Join(nestedFieldNames, ", "),
 	)
-	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("func (x *", msgName, ") UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {")
 	gf.P("var raw map[string]json.RawMessage")
 	gf.P("if err := json.Unmarshal(data, &raw); err != nil {")
 	gf.P("return err")
@@ -554,22 +562,27 @@ func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 	for _, field := range ctx.NestedFields {
 		jsonName := field.Desc.JSONName()
 		if field.Desc.IsList() {
-			// Repeated field: the JSON value is an array. Unmarshal as a slice so each
-			// element's custom UnmarshalJSON is called, then re-marshal each element
-			// back to protojson format for the final protojson.Unmarshal call.
-			gf.P("// Handle repeated \"", jsonName, "\" using its custom UnmarshalJSON")
+			// Repeated field: decode as raw items so we can dispatch each element
+			// through UnmarshalJSONSebuf (opts propagation) or json.Unmarshaler fallback.
+			gf.P("// Handle repeated \"", jsonName, "\" using its custom unmarshaler")
 			gf.P("if rawVal, ok := raw[\"", jsonName, "\"]; ok {")
-			gf.P("var innerList []*", gf.QualifiedGoIdent(field.Message.GoIdent))
-			gf.P("if err := json.Unmarshal(rawVal, &innerList); err != nil {")
+			gf.P("var rawItems []json.RawMessage")
+			gf.P("if err := json.Unmarshal(rawVal, &rawItems); err != nil {")
 			gf.P("return err")
 			gf.P("}")
-			gf.P("protoItems := make([]json.RawMessage, len(innerList))")
-			gf.P("for i, item := range innerList {")
-			gf.P("if item == nil {")
-			gf.P("protoItems[i] = json.RawMessage(\"null\")")
-			gf.P("continue")
+			gf.P("protoItems := make([]json.RawMessage, len(rawItems))")
+			gf.P("for i, itemRaw := range rawItems {")
+			gf.P("inner := &", gf.QualifiedGoIdent(field.Message.GoIdent), "{}")
+			gf.P(
+				"if u, ok := any(inner).(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {",
+			)
+			gf.P("if err := u.UnmarshalJSONSebuf(itemRaw, opts); err != nil {")
+			gf.P("return err")
 			gf.P("}")
-			gf.P("itemJSON, marshalErr := protojson.Marshal(item)")
+			gf.P("} else if err := json.Unmarshal(itemRaw, inner); err != nil {")
+			gf.P("return err")
+			gf.P("}")
+			gf.P("itemJSON, marshalErr := protojson.Marshal(inner)")
 			gf.P("if marshalErr != nil {")
 			gf.P("return marshalErr")
 			gf.P("}")
@@ -583,11 +596,17 @@ func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 			gf.P("}")
 			gf.P()
 		} else {
-			// Singular field: unmarshal as a single pointer, re-marshal with protojson.
-			gf.P("// Handle \"", jsonName, "\" using its custom UnmarshalJSON")
+			// Singular field: dispatch through UnmarshalJSONSebuf or json.Unmarshaler fallback.
+			gf.P("// Handle \"", jsonName, "\" using its custom unmarshaler")
 			gf.P("if rawVal, ok := raw[\"", jsonName, "\"]; ok {")
 			gf.P("inner := &", gf.QualifiedGoIdent(field.Message.GoIdent), "{}")
-			gf.P("if err := json.Unmarshal(rawVal, inner); err != nil {")
+			gf.P(
+				"if u, ok := any(inner).(interface{ UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error }); ok {",
+			)
+			gf.P("if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {")
+			gf.P("return err")
+			gf.P("}")
+			gf.P("} else if err := json.Unmarshal(rawVal, inner); err != nil {")
 			gf.P("return err")
 			gf.P("}")
 			gf.P("innerJSON, err := protojson.Marshal(inner)")
@@ -605,7 +624,14 @@ func (g *Generator) generateWrapperUnmarshalJSON(gf *protogen.GeneratedFile, ctx
 	gf.P("return err")
 	gf.P("}")
 	gf.P()
-	gf.P("return protojson.Unmarshal(modified, x)")
+	gf.P("return opts.Unmarshal(modified, x)")
+	gf.P("}")
+	gf.P()
+
+	// Backward-compatible UnmarshalJSON wrapper for stdlib encoding/json
+	gf.P("// UnmarshalJSON implements json.Unmarshaler for ", msgName, ".")
+	gf.P("func (x *", msgName, ") UnmarshalJSON(data []byte) error {")
+	gf.P("return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})")
 	gf.P("}")
 	gf.P()
 }

--- a/internal/httpgen/testdata/golden/cross_int64_bar_encoding.pb.go
+++ b/internal/httpgen/testdata/golden/cross_int64_bar_encoding.pb.go
@@ -46,9 +46,9 @@ func (x *Bar) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Bar.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for Bar.
 // This method handles int64_encoding=NUMBER fields: volume
-func (x *Bar) UnmarshalJSON(data []byte) error {
+func (x *Bar) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -70,5 +70,10 @@ func (x *Bar) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Bar.
+func (x *Bar) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/httpgen/testdata/golden/int64_encoding_encoding.pb.go
+++ b/internal/httpgen/testdata/golden/int64_encoding_encoding.pb.go
@@ -99,9 +99,9 @@ func (x *Int64EncodingTest) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Int64EncodingTest.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for Int64EncodingTest.
 // This method handles int64_encoding=NUMBER fields: number_int64, number_uint64, number_sint64, number_sfixed64, number_fixed64, repeated_number_int64, optional_number_int64, commented_number_int64
-func (x *Int64EncodingTest) UnmarshalJSON(data []byte) error {
+func (x *Int64EncodingTest) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -183,5 +183,10 @@ func (x *Int64EncodingTest) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Int64EncodingTest.
+func (x *Int64EncodingTest) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/httpgen/testdata/golden/int64_nested_encoding_encoding.pb.go
+++ b/internal/httpgen/testdata/golden/int64_nested_encoding_encoding.pb.go
@@ -51,9 +51,9 @@ func (x *SensorReading) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for SensorReading.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for SensorReading.
 // This method handles int64_encoding=NUMBER fields: timestamp_ms, values
-func (x *SensorReading) UnmarshalJSON(data []byte) error {
+func (x *SensorReading) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -87,7 +87,12 @@ func (x *SensorReading) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for SensorReading.
+func (x *SensorReading) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSONSebuf implements sebufMarshaler for GetSensorReadingResponse.
@@ -131,18 +136,24 @@ func (x *GetSensorReadingResponse) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for GetSensorReadingResponse.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for GetSensorReadingResponse.
 // This method handles nested messages that have int64_encoding=NUMBER fields: reading
-func (x *GetSensorReadingResponse) UnmarshalJSON(data []byte) error {
+func (x *GetSensorReadingResponse) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	// Handle "reading" using its custom UnmarshalJSON
+	// Handle "reading" using its custom unmarshaler
 	if rawVal, ok := raw["reading"]; ok {
 		inner := &SensorReading{}
-		if err := json.Unmarshal(rawVal, inner); err != nil {
+		if u, ok := any(inner).(interface {
+			UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+		}); ok {
+			if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {
+				return err
+			}
+		} else if err := json.Unmarshal(rawVal, inner); err != nil {
 			return err
 		}
 		innerJSON, err := protojson.Marshal(inner)
@@ -157,7 +168,12 @@ func (x *GetSensorReadingResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for GetSensorReadingResponse.
+func (x *GetSensorReadingResponse) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSONSebuf implements sebufMarshaler for GetMultiSensorResponse.
@@ -215,18 +231,24 @@ func (x *GetMultiSensorResponse) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for GetMultiSensorResponse.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for GetMultiSensorResponse.
 // This method handles nested messages that have int64_encoding=NUMBER fields: primary, secondary
-func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
+func (x *GetMultiSensorResponse) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	// Handle "primary" using its custom UnmarshalJSON
+	// Handle "primary" using its custom unmarshaler
 	if rawVal, ok := raw["primary"]; ok {
 		inner := &SensorReading{}
-		if err := json.Unmarshal(rawVal, inner); err != nil {
+		if u, ok := any(inner).(interface {
+			UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+		}); ok {
+			if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {
+				return err
+			}
+		} else if err := json.Unmarshal(rawVal, inner); err != nil {
 			return err
 		}
 		innerJSON, err := protojson.Marshal(inner)
@@ -236,10 +258,16 @@ func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
 		raw["primary"] = innerJSON
 	}
 
-	// Handle "secondary" using its custom UnmarshalJSON
+	// Handle "secondary" using its custom unmarshaler
 	if rawVal, ok := raw["secondary"]; ok {
 		inner := &SensorReading{}
-		if err := json.Unmarshal(rawVal, inner); err != nil {
+		if u, ok := any(inner).(interface {
+			UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+		}); ok {
+			if err := u.UnmarshalJSONSebuf(rawVal, opts); err != nil {
+				return err
+			}
+		} else if err := json.Unmarshal(rawVal, inner); err != nil {
 			return err
 		}
 		innerJSON, err := protojson.Marshal(inner)
@@ -254,5 +282,10 @@ func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for GetMultiSensorResponse.
+func (x *GetMultiSensorResponse) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/httpgen/testdata/golden/int64_repeated_nested_encoding_encoding.pb.go
+++ b/internal/httpgen/testdata/golden/int64_repeated_nested_encoding_encoding.pb.go
@@ -46,9 +46,9 @@ func (x *Stock) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Stock.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for Stock.
 // This method handles int64_encoding=NUMBER fields: volume
-func (x *Stock) UnmarshalJSON(data []byte) error {
+func (x *Stock) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -70,7 +70,12 @@ func (x *Stock) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Stock.
+func (x *Stock) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSONSebuf implements sebufMarshaler for GetStocksResponse.
@@ -126,27 +131,33 @@ func (x *GetStocksResponse) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for GetStocksResponse.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for GetStocksResponse.
 // This method handles nested messages that have int64_encoding=NUMBER fields: stocks
-func (x *GetStocksResponse) UnmarshalJSON(data []byte) error {
+func (x *GetStocksResponse) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	// Handle repeated "stocks" using its custom UnmarshalJSON
+	// Handle repeated "stocks" using its custom unmarshaler
 	if rawVal, ok := raw["stocks"]; ok {
-		var innerList []*Stock
-		if err := json.Unmarshal(rawVal, &innerList); err != nil {
+		var rawItems []json.RawMessage
+		if err := json.Unmarshal(rawVal, &rawItems); err != nil {
 			return err
 		}
-		protoItems := make([]json.RawMessage, len(innerList))
-		for i, item := range innerList {
-			if item == nil {
-				protoItems[i] = json.RawMessage("null")
-				continue
+		protoItems := make([]json.RawMessage, len(rawItems))
+		for i, itemRaw := range rawItems {
+			inner := &Stock{}
+			if u, ok := any(inner).(interface {
+				UnmarshalJSONSebuf([]byte, protojson.UnmarshalOptions) error
+			}); ok {
+				if err := u.UnmarshalJSONSebuf(itemRaw, opts); err != nil {
+					return err
+				}
+			} else if err := json.Unmarshal(itemRaw, inner); err != nil {
+				return err
 			}
-			itemJSON, marshalErr := protojson.Marshal(item)
+			itemJSON, marshalErr := protojson.Marshal(inner)
 			if marshalErr != nil {
 				return marshalErr
 			}
@@ -164,5 +175,10 @@ func (x *GetStocksResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for GetStocksResponse.
+func (x *GetStocksResponse) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }

--- a/internal/httpgen/testdata/golden/unwrap_int64_encoding_encoding.pb.go
+++ b/internal/httpgen/testdata/golden/unwrap_int64_encoding_encoding.pb.go
@@ -46,9 +46,9 @@ func (x *Bar) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Bar.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for Bar.
 // This method handles int64_encoding=NUMBER fields: volume
-func (x *Bar) UnmarshalJSON(data []byte) error {
+func (x *Bar) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -70,7 +70,12 @@ func (x *Bar) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Bar.
+func (x *Bar) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }
 
 // MarshalJSONSebuf implements sebufMarshaler for Meta.
@@ -109,9 +114,9 @@ func (x *Meta) MarshalJSON() ([]byte, error) {
 	return x.MarshalJSONSebuf(protojson.MarshalOptions{})
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Meta.
+// UnmarshalJSONSebuf implements sebufUnmarshaler for Meta.
 // This method handles int64_encoding=NUMBER fields: timestamp
-func (x *Meta) UnmarshalJSON(data []byte) error {
+func (x *Meta) UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error {
 	// First, parse the raw JSON to extract NUMBER-encoded fields
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -133,5 +138,10 @@ func (x *Meta) UnmarshalJSON(data []byte) error {
 	}
 
 	// Use protojson to unmarshal the rest
-	return protojson.Unmarshal(modified, x)
+	return opts.Unmarshal(modified, x)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Meta.
+func (x *Meta) UnmarshalJSON(data []byte) error {
+	return x.UnmarshalJSONSebuf(data, protojson.UnmarshalOptions{})
 }


### PR DESCRIPTION
## Problem

`protoc-gen-go-http` generated `UnmarshalJSON` (`json.Unmarshaler`) for messages with `int64_encoding=NUMBER` fields, but not `UnmarshalJSONSebuf` (`sebufUnmarshaler`). `unmarshalResponse` checks `sebufUnmarshaler` first; when that check fails it falls through to `json.Unmarshaler`, which calls `protojson.Unmarshal` with **default options** — silently dropping the `DiscardUnknown` flag even when `WithV1CallDiscardUnknownFields(true)` is set on the call.

## Fix

Both `generateInt64UnmarshalJSON` and `generateWrapperUnmarshalJSON` now emit:
- `UnmarshalJSONSebuf(data []byte, opts protojson.UnmarshalOptions) error` — the primary method, propagates `opts` through all nested message dispatches and the final `opts.Unmarshal` call
- `UnmarshalJSON(data []byte) error` — backward-compatible shim that calls `UnmarshalJSONSebuf` with empty options

This mirrors the pattern already used by `protoc-gen-go-client`.

## Testing

All `TestHTTPGenGoldenFiles/int64_*` tests updated and passing. Full `httpgen` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)