### PR TITLE
fix(codegen): reject non-scalar query and path parameters at generation time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -547,6 +547,28 @@ All custom annotations live in `proto/sebuf/http/annotations.proto`:
 | 50019 | flatten | FieldOptions | Nested message flattening |
 | 50020 | flatten_prefix | FieldOptions | Prefix for flattened fields |
 
+### URL Parameter Types Must Be Scalar
+
+Query (`sebuf.http.query`) and path parameters accept only scalar kinds — string,
+bool, the integer families, float/double, and enum — plus repeated scalars for query
+params. `message`, `group`, `bytes`, and `map` have no canonical URL encoding and are
+**rejected at generation time by all six generators**.
+
+The single source of truth is `internal/annotations/url_params.go`:
+`IsURLParamKindCompatible` (the kind predicate) and `ValidateFileURLParams` (the
+per-file entry point every generator calls). httpgen routes it through its own
+aggregating `ValidateMethodConfig`; the other five call `ValidateFileURLParams`
+directly before emitting anything.
+
+A shared helper alone does not keep the plugins aligned — `ValidateTimestampFormatAnnotation`
+is shared too and only two of six ever wired it in. `internal/urlparamtest` is the
+anti-drift guard: it drives all six generators over the same fixtures and asserts they
+reject and accept identically. Add a generator there when you add a generator.
+
+Notably, this makes the **typed-ID pattern** (`UserClientID { string value = 1 }`) invalid
+as a query/path param; use a scalar field with `(buf.validate.field).string.uuid` instead.
+See [docs/http-generation.md](docs/http-generation.md#unsupported-parameter-types) and issue #216.
+
 ## Development Commands
 
 ### Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -550,13 +550,20 @@ All custom annotations live in `proto/sebuf/http/annotations.proto`:
 ### URL Parameter Types Must Be Scalar
 
 Query (`sebuf.http.query`) and path parameters accept only scalar kinds — string,
-bool, the integer families, float/double, and enum — plus repeated scalars for query
-params. `message`, `group`, `bytes`, and `map` have no canonical URL encoding and are
-**rejected at generation time by all six generators**.
+bool, the integer families, float/double, and enum. `message`, `group`, `bytes`, and
+`map` have no canonical URL encoding and are **rejected at generation time by all six
+generators**.
+
+Cardinality differs by location: repeated scalars are valid query params
+(`?ids=a&ids=b`) but never valid path variables, since a path variable matches exactly
+one URL segment. Accepting a repeated path variable makes the generated Go server
+*panic* at request time — `bindPathParams` calls `reflectMsg.Set(field, scalarValue)`,
+which protoreflect rejects on a list field.
 
 The single source of truth is `internal/annotations/url_params.go`:
-`IsURLParamKindCompatible` (the kind predicate) and `ValidateFileURLParams` (the
-per-file entry point every generator calls). httpgen routes it through its own
+`IsURLParamKindCompatible` (the kind predicate), `ValidatePathParamField` (kind +
+cardinality, for path variables), and `ValidateFileURLParams` (the per-file entry point
+every generator calls). httpgen routes it through its own
 aggregating `ValidateMethodConfig`; the other five call `ValidateFileURLParams`
 directly before emitting anything.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,13 +583,20 @@ All custom annotations live in `proto/sebuf/http/annotations.proto`:
 ### URL Parameter Types Must Be Scalar
 
 Query (`sebuf.http.query`) and path parameters accept only scalar kinds — string,
-bool, the integer families, float/double, and enum — plus repeated scalars for query
-params. `message`, `group`, `bytes`, and `map` have no canonical URL encoding and are
-**rejected at generation time by all six generators**.
+bool, the integer families, float/double, and enum. `message`, `group`, `bytes`, and
+`map` have no canonical URL encoding and are **rejected at generation time by all six
+generators**.
+
+Cardinality differs by location: repeated scalars are valid query params
+(`?ids=a&ids=b`) but never valid path variables, since a path variable matches exactly
+one URL segment. Accepting a repeated path variable makes the generated Go server
+*panic* at request time — `bindPathParams` calls `reflectMsg.Set(field, scalarValue)`,
+which protoreflect rejects on a list field.
 
 The single source of truth is `internal/annotations/url_params.go`:
-`IsURLParamKindCompatible` (the kind predicate) and `ValidateFileURLParams` (the
-per-file entry point every generator calls). httpgen routes it through its own
+`IsURLParamKindCompatible` (the kind predicate), `ValidatePathParamField` (kind +
+cardinality, for path variables), and `ValidateFileURLParams` (the per-file entry point
+every generator calls). httpgen routes it through its own
 aggregating `ValidateMethodConfig`; the other five call `ValidateFileURLParams`
 directly before emitting anything.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -580,6 +580,28 @@ All custom annotations live in `proto/sebuf/http/annotations.proto`:
 | 50019 | flatten | FieldOptions | Nested message flattening |
 | 50020 | flatten_prefix | FieldOptions | Prefix for flattened fields |
 
+### URL Parameter Types Must Be Scalar
+
+Query (`sebuf.http.query`) and path parameters accept only scalar kinds — string,
+bool, the integer families, float/double, and enum — plus repeated scalars for query
+params. `message`, `group`, `bytes`, and `map` have no canonical URL encoding and are
+**rejected at generation time by all six generators**.
+
+The single source of truth is `internal/annotations/url_params.go`:
+`IsURLParamKindCompatible` (the kind predicate) and `ValidateFileURLParams` (the
+per-file entry point every generator calls). httpgen routes it through its own
+aggregating `ValidateMethodConfig`; the other five call `ValidateFileURLParams`
+directly before emitting anything.
+
+A shared helper alone does not keep the plugins aligned — `ValidateTimestampFormatAnnotation`
+is shared too and only two of six ever wired it in. `internal/urlparamtest` is the
+anti-drift guard: it drives all six generators over the same fixtures and asserts they
+reject and accept identically. Add a generator there when you add a generator.
+
+Notably, this makes the **typed-ID pattern** (`UserClientID { string value = 1 }`) invalid
+as a query/path param; use a scalar field with `(buf.validate.field).string.uuid` instead.
+See [docs/http-generation.md](docs/http-generation.md#unsupported-parameter-types) and issue #216.
+
 ## Development Commands
 
 ### Testing

--- a/cmd/protoc-gen-openapiv3/main.go
+++ b/cmd/protoc-gen-openapiv3/main.go
@@ -109,6 +109,14 @@ func createPlugin(req *pluginpb.CodeGeneratorRequest) *protogen.Plugin {
 }
 
 func generateOpenAPIFiles(plugin *protogen.Plugin, format openapiv3.OutputFormat, bundle bundleConfig) {
+	// Reject path/query params whose types cannot be represented in a URL before
+	// emitting anything, so an invalid proto fails cleanly instead of documenting a
+	// contract no generator implements.
+	if err := openapiv3.ValidateFiles(plugin); err != nil {
+		plugin.Error(err)
+		return
+	}
+
 	// Per-service output (default behaviour; suppressed when bundle_only=true).
 	if !bundle.enabled || !bundle.onlyBundle {
 		for _, file := range plugin.Files {

--- a/docs/http-generation.md
+++ b/docs/http-generation.md
@@ -357,13 +357,28 @@ Query and path parameters support the following scalar types:
 | `float`, `double` | `?min_score=3.5` | |
 | `enum` | `?region=REGION_AMERICAS` or `?region=1` | Accepts proto enum name (case-sensitive) or numeric value |
 
-Repeated fields are supported for query parameters (`?tags=a&tags=b`).
+Repeated fields are supported for **query parameters only** (`?tags=a&tags=b`). A path
+variable matches exactly one URL segment, so a `repeated` field bound to one is rejected
+at generation time:
+
+```protobuf
+// ❌ Rejected: a path variable cannot be repeated
+message GetItemsRequest {
+  repeated string ids = 1;   // bound to "/items/{ids}"
+}
+
+// ✅ Use a query parameter instead
+message GetItemsRequest {
+  repeated string ids = 1 [(sebuf.http.query) = {name: "ids"}];   // ?ids=a&ids=b
+}
+```
 
 ### Unsupported Parameter Types
 
 `message`, `group`, `bytes`, and `map` fields **cannot** be bound to a query or path
-parameter — there is no canonical URL encoding for them. All six generators reject
-them at generation time with an error naming the field and its type:
+parameter — there is no canonical URL encoding for them. (Path parameters additionally
+reject `repeated` fields, as above.) All six generators reject these at generation time
+with an error naming the field and its type:
 
 ```
 AuthorizationService.ListClientRestrictions: field 'client_id' on message

--- a/docs/http-generation.md
+++ b/docs/http-generation.md
@@ -359,6 +359,46 @@ Query and path parameters support the following scalar types:
 
 Repeated fields are supported for query parameters (`?tags=a&tags=b`).
 
+### Unsupported Parameter Types
+
+`message`, `group`, `bytes`, and `map` fields **cannot** be bound to a query or path
+parameter — there is no canonical URL encoding for them. All six generators reject
+them at generation time with an error naming the field and its type:
+
+```
+AuthorizationService.ListClientRestrictions: field 'client_id' on message
+'ListClientRestrictionsRequest' is annotated with (sebuf.http.query) as parameter
+'clientId', but has unsupported type 'message (core.v1.UserClientID)'. Query
+parameters must be scalar types (...) or repeated scalars. Replace it with a scalar
+field, or move it into the request body by using POST/PUT/PATCH.
+```
+
+This most often shows up with the **typed-ID pattern** — a wrapper message whose only
+field is a scalar:
+
+```protobuf
+// ❌ Rejected: UserClientID is a message
+message ListClientRestrictionsRequest {
+  core.v1.UserClientID client_id = 1 [(sebuf.http.query) = {name: "clientId"}];
+}
+```
+
+Use a scalar field instead. Validation is preserved, and the wrapper type can still be
+used everywhere else in your schema:
+
+```protobuf
+// ✅ Accepted
+message ListClientRestrictionsRequest {
+  string client_id = 1 [
+    (buf.validate.field).string.uuid = true,
+    (sebuf.http.query) = {name: "clientId", required: true}
+  ];
+}
+```
+
+If the field genuinely needs to be a message, move it into the request body by
+switching the method to `POST`/`PUT`/`PATCH`.
+
 ### Enum Parameters
 
 Enum fields work as both query and path parameters. They accept:

--- a/docs/http-generation.md
+++ b/docs/http-generation.md
@@ -424,6 +424,13 @@ Enum fields work as both query and path parameters. They accept:
 
 Invalid enum names return a 400 validation error mentioning the enum type.
 
+> **Known limitation ([#219](https://github.com/SebastienMelki/sebuf/issues/219))**: the
+> `(sebuf.http.enum_value)` custom string is applied to JSON bodies but **not** to query or
+> path parameters. The Go client and server use the proto enum name (`REGION_AMERICAS`)
+> there, while the TypeScript client sends the custom string (`americas`) — which the Go
+> server currently rejects. Until that is resolved, avoid `enum_value` on enums used as
+> URL parameters if you need cross-language clients, or send the numeric value.
+
 ```protobuf
 enum Region {
   REGION_UNSPECIFIED = 0;

--- a/internal/annotations/url_params.go
+++ b/internal/annotations/url_params.go
@@ -1,0 +1,182 @@
+package annotations
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// URLParamScalarKinds is the human-readable list of proto field kinds that can be
+// bound from a URL. It is shared by every generator's error message so the wording
+// cannot drift between plugins.
+const URLParamScalarKinds = "string, int32, int64, uint32, uint64, bool, float, double, enum"
+
+// URL parameter locations, used by URLParamValidationError.
+const (
+	URLParamLocationPath  = "path"
+	URLParamLocationQuery = "query"
+)
+
+// URLParamValidationError describes a field bound to a URL path or query parameter
+// whose type cannot be represented in a URL.
+type URLParamValidationError struct {
+	MessageName string // Request message name (e.g., "ListClientRestrictionsRequest")
+	FieldName   string // Proto field name (e.g., "client_id")
+	ParamName   string // Path variable or query parameter name (e.g., "clientId")
+	Location    string // URLParamLocationPath or URLParamLocationQuery
+	TypeName    string // Descriptive field type (e.g., "message (core.v1.UserClientID)")
+}
+
+func (e *URLParamValidationError) Error() string {
+	if e.Location == URLParamLocationPath {
+		return fmt.Sprintf(
+			"path variable '{%s}' is bound to field '%s' on message '%s' of type '%s', "+
+				"but path parameters must be scalar types (%s). "+
+				"Change the field type or remove it from the path.",
+			e.ParamName, e.FieldName, e.MessageName, e.TypeName, URLParamScalarKinds)
+	}
+
+	return fmt.Sprintf(
+		"field '%s' on message '%s' is annotated with (sebuf.http.query) as parameter '%s', "+
+			"but has unsupported type '%s'. Query parameters must be scalar types (%s) "+
+			"or repeated scalars. Replace it with a scalar field, or move it into the "+
+			"request body by using POST/PUT/PATCH.",
+		e.FieldName, e.MessageName, e.ParamName, e.TypeName, URLParamScalarKinds)
+}
+
+// IsURLParamKindCompatible reports whether a proto field kind can be represented in a
+// URL path segment or query value.
+//
+// Message, group, and bytes kinds cannot: there is no canonical URL encoding for them,
+// and every generator previously fell through to a string-shaped default that produced
+// non-compiling Go, corrupted Python/TypeScript values, or a runtime 400. See issue #216.
+func IsURLParamKindCompatible(kind protoreflect.Kind) bool {
+	switch kind {
+	case protoreflect.StringKind,
+		protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
+		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
+		protoreflect.Uint32Kind, protoreflect.Fixed32Kind,
+		protoreflect.Uint64Kind, protoreflect.Fixed64Kind,
+		protoreflect.BoolKind,
+		protoreflect.FloatKind, protoreflect.DoubleKind,
+		protoreflect.EnumKind:
+		return true
+	case protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
+		return false
+	}
+	return false
+}
+
+// IsURLParamCompatible reports whether a field can be bound from a URL path segment or
+// query value. Map fields report MessageKind and are therefore rejected as well.
+func IsURLParamCompatible(field *protogen.Field) bool {
+	return IsURLParamKindCompatible(field.Desc.Kind())
+}
+
+// URLParamTypeName returns a descriptive type name for a field, used in validation
+// errors. Message-kind fields are qualified with their full proto type name so the
+// error names the offending type rather than just "message".
+func URLParamTypeName(field *protogen.Field) string {
+	if field.Desc.IsMap() {
+		return "map"
+	}
+
+	kind := field.Desc.Kind().String()
+	if field.Desc.Kind() == protoreflect.MessageKind && field.Message != nil {
+		return fmt.Sprintf("%s (%s)", kind, field.Message.Desc.FullName())
+	}
+
+	return kind
+}
+
+// ValidateQueryParams checks that every (sebuf.http.query)-annotated field on message
+// has a type that can be represented in a query string. Returns the first error found.
+func ValidateQueryParams(message *protogen.Message) error {
+	for _, qp := range GetQueryParams(message) {
+		if IsURLParamCompatible(qp.Field) {
+			continue
+		}
+
+		return &URLParamValidationError{
+			MessageName: string(message.Desc.Name()),
+			FieldName:   qp.FieldName,
+			ParamName:   qp.ParamName,
+			Location:    URLParamLocationQuery,
+			TypeName:    URLParamTypeName(qp.Field),
+		}
+	}
+
+	return nil
+}
+
+// ValidatePathParams checks that every path variable on the method's HTTP config is
+// bound to a field whose type can be represented in a URL path segment.
+//
+// Path variables with no matching field are skipped: that is a separate diagnostic,
+// reported by httpgen so it is not duplicated across every plugin.
+func ValidatePathParams(method *protogen.Method) error {
+	config := GetMethodHTTPConfig(method)
+	if config == nil {
+		return nil
+	}
+
+	for _, param := range config.PathParams {
+		field := FindFieldByProtoName(method.Input, param)
+		if field == nil || IsURLParamCompatible(field) {
+			continue
+		}
+
+		return &URLParamValidationError{
+			MessageName: string(method.Input.Desc.Name()),
+			FieldName:   string(field.Desc.Name()),
+			ParamName:   param,
+			Location:    URLParamLocationPath,
+			TypeName:    URLParamTypeName(field),
+		}
+	}
+
+	return nil
+}
+
+// ValidateMethodURLParams validates that every path- and query-bound field of the
+// method's request message has a URL-representable type.
+//
+// Every generator calls this so a proto that cannot be generated correctly fails at
+// generation time with one clear message, rather than producing broken output that
+// differs per plugin.
+func ValidateMethodURLParams(method *protogen.Method) error {
+	if err := ValidatePathParams(method); err != nil {
+		return err
+	}
+
+	return ValidateQueryParams(method.Input)
+}
+
+// ValidateFileURLParams validates the URL parameters of every method of every service
+// in the file. This is the single call site each generator wires in, so all six plugins
+// reject the same protos with the same message.
+//
+// The "Service.Method: " prefix matches httpgen's ValidateService formatting.
+func ValidateFileURLParams(file *protogen.File) error {
+	for _, service := range file.Services {
+		for _, method := range service.Methods {
+			if err := ValidateMethodURLParams(method); err != nil {
+				return fmt.Errorf("%s.%s: %w", service.Desc.Name(), method.Desc.Name(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// FindFieldByProtoName returns the field with the given proto name, or nil.
+func FindFieldByProtoName(message *protogen.Message, fieldName string) *protogen.Field {
+	for _, field := range message.Fields {
+		if string(field.Desc.Name()) == fieldName {
+			return field
+		}
+	}
+
+	return nil
+}

--- a/internal/annotations/url_params.go
+++ b/internal/annotations/url_params.go
@@ -26,10 +26,20 @@ type URLParamValidationError struct {
 	ParamName   string // Path variable or query parameter name (e.g., "clientId")
 	Location    string // URLParamLocationPath or URLParamLocationQuery
 	TypeName    string // Descriptive field type (e.g., "message (core.v1.UserClientID)")
+	Repeated    bool   // Field is repeated, which is only ever valid for query params
 }
 
 func (e *URLParamValidationError) Error() string {
 	if e.Location == URLParamLocationPath {
+		if e.Repeated {
+			return fmt.Sprintf(
+				"path variable '{%s}' is bound to field '%s' on message '%s' of type '%s', "+
+					"but a path variable matches a single URL segment and cannot be repeated. "+
+					"Remove the repeated label, or bind the field as a query parameter with "+
+					"(sebuf.http.query) instead.",
+				e.ParamName, e.FieldName, e.MessageName, e.TypeName)
+		}
+
 		return fmt.Sprintf(
 			"path variable '{%s}' is bound to field '%s' on message '%s' of type '%s', "+
 				"but path parameters must be scalar types (%s). "+
@@ -84,10 +94,50 @@ func URLParamTypeName(field *protogen.Field) string {
 
 	kind := field.Desc.Kind().String()
 	if field.Desc.Kind() == protoreflect.MessageKind && field.Message != nil {
-		return fmt.Sprintf("%s (%s)", kind, field.Message.Desc.FullName())
+		kind = fmt.Sprintf("%s (%s)", kind, field.Message.Desc.FullName())
+	}
+
+	if field.Desc.IsList() {
+		kind = "repeated " + kind
 	}
 
 	return kind
+}
+
+// ValidatePathParamField reports why a field cannot be bound to a path variable, or
+// nil if it can. Both this package's ValidatePathParams and httpgen's aggregating
+// validator call it, so the two cannot disagree.
+//
+// Repeated fields are rejected here but allowed as query parameters (?tags=a&tags=b):
+// a path variable matches exactly one URL segment. Accepting one would make the
+// generated Go server panic at request time — bindPathParams does
+// reflectMsg.Set(field, scalarValue), and protoreflect rejects that on a list field
+// with "type mismatch: cannot convert string to list".
+func ValidatePathParamField(field *protogen.Field, paramName, messageName string) *URLParamValidationError {
+	// Kind first: it is the more fundamental problem. For a `repeated SomeMessage`
+	// path variable, dropping the repeated label still would not make it bindable.
+	if !IsURLParamCompatible(field) {
+		return &URLParamValidationError{
+			MessageName: messageName,
+			FieldName:   string(field.Desc.Name()),
+			ParamName:   paramName,
+			Location:    URLParamLocationPath,
+			TypeName:    URLParamTypeName(field),
+		}
+	}
+
+	if field.Desc.IsList() {
+		return &URLParamValidationError{
+			MessageName: messageName,
+			FieldName:   string(field.Desc.Name()),
+			ParamName:   paramName,
+			Location:    URLParamLocationPath,
+			TypeName:    URLParamTypeName(field),
+			Repeated:    true,
+		}
+	}
+
+	return nil
 }
 
 // ValidateQueryParams checks that every (sebuf.http.query)-annotated field on message
@@ -121,18 +171,16 @@ func ValidatePathParams(method *protogen.Method) error {
 		return nil
 	}
 
+	messageName := string(method.Input.Desc.Name())
+
 	for _, param := range config.PathParams {
 		field := FindFieldByProtoName(method.Input, param)
-		if field == nil || IsURLParamCompatible(field) {
+		if field == nil {
 			continue
 		}
 
-		return &URLParamValidationError{
-			MessageName: string(method.Input.Desc.Name()),
-			FieldName:   string(field.Desc.Name()),
-			ParamName:   param,
-			Location:    URLParamLocationPath,
-			TypeName:    URLParamTypeName(field),
+		if err := ValidatePathParamField(field, param, messageName); err != nil {
+			return err
 		}
 	}
 

--- a/internal/annotations/url_params_test.go
+++ b/internal/annotations/url_params_test.go
@@ -151,6 +151,26 @@ func TestValidateFileURLParams(t *testing.T) {
 			wantErr: "path variable '{client_id}'",
 		},
 		{
+			// Kind is `string`, so only the IsList check catches this.
+			name: "repeated scalar path param is rejected",
+			file: buildTestFile(
+				repeated(plainField("ids", descriptorpb.FieldDescriptorProto_TYPE_STRING, "")),
+				"/items/{ids}",
+			),
+			wantErr: "cannot be repeated",
+		},
+		{
+			// Kind is reported ahead of cardinality: dropping `repeated` alone would
+			// still leave this unbindable.
+			name: "repeated message path param reports the kind, not the repetition",
+			file: buildTestFile(
+				repeated(plainField("ids", descriptorpb.FieldDescriptorProto_TYPE_MESSAGE,
+					".test.UserClientID")),
+				"/items/{ids}",
+			),
+			wantErr: "must be scalar types",
+		},
+		{
 			name: "path variable with no matching field is left to httpgen",
 			file: buildTestFile(
 				plainField("id", descriptorpb.FieldDescriptorProto_TYPE_STRING, ""),

--- a/internal/annotations/url_params_test.go
+++ b/internal/annotations/url_params_test.go
@@ -1,0 +1,324 @@
+package annotations
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
+
+	"github.com/SebastienMelki/sebuf/http"
+)
+
+func TestIsURLParamKindCompatible(t *testing.T) {
+	compatible := []protoreflect.Kind{
+		protoreflect.StringKind,
+		protoreflect.BoolKind,
+		protoreflect.EnumKind,
+		protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
+		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
+		protoreflect.Uint32Kind, protoreflect.Fixed32Kind,
+		protoreflect.Uint64Kind, protoreflect.Fixed64Kind,
+		protoreflect.FloatKind, protoreflect.DoubleKind,
+	}
+	for _, kind := range compatible {
+		if !IsURLParamKindCompatible(kind) {
+			t.Errorf("kind %v should be URL-param compatible", kind)
+		}
+	}
+
+	// These are the kinds behind issue #216: every generator used to fall through to
+	// a string-shaped default for them.
+	incompatible := []protoreflect.Kind{
+		protoreflect.MessageKind,
+		protoreflect.GroupKind,
+		protoreflect.BytesKind,
+	}
+	for _, kind := range incompatible {
+		if IsURLParamKindCompatible(kind) {
+			t.Errorf("kind %v should NOT be URL-param compatible", kind)
+		}
+	}
+
+	if IsURLParamKindCompatible(protoreflect.Kind(0)) {
+		t.Error("unknown kind should not be URL-param compatible")
+	}
+}
+
+func TestURLParamValidationError_Query(t *testing.T) {
+	err := &URLParamValidationError{
+		MessageName: "ListClientRestrictionsRequest",
+		FieldName:   "client_id",
+		ParamName:   "clientId",
+		Location:    URLParamLocationQuery,
+		TypeName:    "message (core.v1.UserClientID)",
+	}
+
+	msg := err.Error()
+	for _, want := range []string{
+		"field 'client_id'",
+		"message 'ListClientRestrictionsRequest'",
+		"(sebuf.http.query) as parameter 'clientId'",
+		"unsupported type 'message (core.v1.UserClientID)'",
+		URLParamScalarKinds,
+		"POST/PUT/PATCH",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("query error missing %q, got: %s", want, msg)
+		}
+	}
+}
+
+func TestURLParamValidationError_Path(t *testing.T) {
+	err := &URLParamValidationError{
+		MessageName: "GetClientRequest",
+		FieldName:   "client_id",
+		ParamName:   "client_id",
+		Location:    URLParamLocationPath,
+		TypeName:    "message (core.v1.UserClientID)",
+	}
+
+	msg := err.Error()
+	for _, want := range []string{
+		"path variable '{client_id}'",
+		"message 'GetClientRequest'",
+		URLParamScalarKinds,
+		"Change the field type or remove it from the path",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("path error missing %q, got: %s", want, msg)
+		}
+	}
+
+	if strings.Contains(msg, "sebuf.http.query") {
+		t.Errorf("path error should not mention the query annotation, got: %s", msg)
+	}
+}
+
+// TestValidateFileURLParams drives the validator over synthesized descriptors, so it
+// runs without protoc. The cross-generator behaviour is covered separately in
+// internal/urlparamtest.
+func TestValidateFileURLParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    *descriptorpb.FileDescriptorProto
+		wantErr string // empty means "must be accepted"
+	}{
+		{
+			name: "scalar query param is accepted",
+			file: buildTestFile(
+				queryField("client_id", descriptorpb.FieldDescriptorProto_TYPE_STRING, "", "clientId"), ""),
+		},
+		{
+			name: "repeated scalar query param is accepted",
+			file: buildTestFile(
+				repeated(queryField("tags", descriptorpb.FieldDescriptorProto_TYPE_STRING, "", "tags")), ""),
+		},
+		{
+			name: "scalar path param is accepted",
+			file: buildTestFile(plainField("id", descriptorpb.FieldDescriptorProto_TYPE_STRING, ""), "/items/{id}"),
+		},
+		{
+			name: "message query param is rejected",
+			file: buildTestFile(
+				queryField("client_id", descriptorpb.FieldDescriptorProto_TYPE_MESSAGE,
+					".test.UserClientID", "clientId"),
+				""),
+			wantErr: "unsupported type 'message (test.UserClientID)'",
+		},
+		{
+			name: "repeated message query param is rejected",
+			file: buildTestFile(
+				repeated(queryField("ids", descriptorpb.FieldDescriptorProto_TYPE_MESSAGE,
+					".test.UserClientID", "ids")),
+				""),
+			wantErr: "field 'ids'",
+		},
+		{
+			name: "bytes query param is rejected",
+			file: buildTestFile(
+				queryField("checksum", descriptorpb.FieldDescriptorProto_TYPE_BYTES, "", "checksum"), ""),
+			wantErr: "unsupported type 'bytes'",
+		},
+		{
+			name: "message path param is rejected",
+			file: buildTestFile(
+				plainField("client_id", descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, ".test.UserClientID"),
+				"/clients/{client_id}"),
+			wantErr: "path variable '{client_id}'",
+		},
+		{
+			name: "path variable with no matching field is left to httpgen",
+			file: buildTestFile(
+				plainField("id", descriptorpb.FieldDescriptorProto_TYPE_STRING, ""),
+				"/items/{missing}",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := loadTestFile(t, tt.file)
+
+			err := ValidateFileURLParams(file)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected the proto to be accepted, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error to contain %q, got: %v", tt.wantErr, err)
+			}
+			// Every error is prefixed with the offending service and method.
+			if !strings.Contains(err.Error(), "ItemService.GetItem:") {
+				t.Errorf("expected error to name the service and method, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateFileURLParams_MapField pins the error wording for map fields: they
+// report MessageKind, but naming the synthetic "GetItemRequestFiltersEntry" type in
+// the error would be noise, so URLParamTypeName collapses them to "map".
+func TestValidateFileURLParams_MapField(t *testing.T) {
+	fd := buildTestFile(
+		repeated(queryField("filters", descriptorpb.FieldDescriptorProto_TYPE_MESSAGE,
+			".test.GetItemRequest.FiltersEntry", "filters")),
+		"",
+	)
+	// Attach the synthetic map-entry type protoc would generate.
+	fd.MessageType[1].NestedType = []*descriptorpb.DescriptorProto{{
+		Name: proto.String("FiltersEntry"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			plainField("key", descriptorpb.FieldDescriptorProto_TYPE_STRING, ""),
+			numbered(plainField("value", descriptorpb.FieldDescriptorProto_TYPE_STRING, ""), 2),
+		},
+		Options: &descriptorpb.MessageOptions{MapEntry: proto.Bool(true)},
+	}}
+
+	err := ValidateFileURLParams(loadTestFile(t, fd))
+	if err == nil {
+		t.Fatal("expected a map query param to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unsupported type 'map'") {
+		t.Errorf("expected the error to name the type as 'map', got: %v", err)
+	}
+}
+
+func TestFindFieldByProtoName(t *testing.T) {
+	file := loadTestFile(t, buildTestFile(plainField("id", descriptorpb.FieldDescriptorProto_TYPE_STRING, ""), ""))
+	request := file.Services[0].Methods[0].Input
+
+	if got := FindFieldByProtoName(request, "id"); got == nil {
+		t.Error("expected to find field 'id'")
+	}
+	if got := FindFieldByProtoName(request, "nope"); got != nil {
+		t.Errorf("expected nil for a missing field, got %v", got.Desc.Name())
+	}
+}
+
+// --- descriptor builders -----------------------------------------------------
+
+func plainField(
+	name string,
+	kind descriptorpb.FieldDescriptorProto_Type,
+	typeName string,
+) *descriptorpb.FieldDescriptorProto {
+	f := &descriptorpb.FieldDescriptorProto{
+		Name:   proto.String(name),
+		Number: proto.Int32(1),
+		Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		Type:   kind.Enum(),
+	}
+	if typeName != "" {
+		f.TypeName = proto.String(typeName)
+	}
+	return f
+}
+
+func queryField(
+	name string,
+	kind descriptorpb.FieldDescriptorProto_Type,
+	typeName, paramName string,
+) *descriptorpb.FieldDescriptorProto {
+	f := plainField(name, kind, typeName)
+	opts := &descriptorpb.FieldOptions{}
+	proto.SetExtension(opts, http.E_Query, &http.QueryConfig{
+		Name:     paramName,
+		Required: true,
+	})
+	f.Options = opts
+	return f
+}
+
+func repeated(f *descriptorpb.FieldDescriptorProto) *descriptorpb.FieldDescriptorProto {
+	f.Label = descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum()
+	return f
+}
+
+func numbered(f *descriptorpb.FieldDescriptorProto, n int32) *descriptorpb.FieldDescriptorProto {
+	f.Number = proto.Int32(n)
+	return f
+}
+
+// buildTestFile assembles a single-service proto around one request field. An empty
+// path means "no HTTP config annotation at all".
+func buildTestFile(field *descriptorpb.FieldDescriptorProto, path string) *descriptorpb.FileDescriptorProto {
+	method := &descriptorpb.MethodDescriptorProto{
+		Name:       proto.String("GetItem"),
+		InputType:  proto.String(".test.GetItemRequest"),
+		OutputType: proto.String(".test.Item"),
+	}
+	if path != "" {
+		opts := &descriptorpb.MethodOptions{}
+		proto.SetExtension(opts, http.E_Config, &http.HttpConfig{
+			Path:   path,
+			Method: http.HttpMethod_HTTP_METHOD_GET,
+		})
+		method.Options = opts
+	}
+
+	return &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("test.proto"),
+		Package: proto.String("test"),
+		Syntax:  proto.String("proto3"),
+		Options: &descriptorpb.FileOptions{
+			GoPackage: proto.String("github.com/SebastienMelki/sebuf/internal/annotations/testpb;testpb"),
+		},
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("UserClientID"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					plainField("value", descriptorpb.FieldDescriptorProto_TYPE_STRING, ""),
+				},
+			},
+			{Name: proto.String("GetItemRequest"), Field: []*descriptorpb.FieldDescriptorProto{field}},
+			{Name: proto.String("Item")},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{Name: proto.String("ItemService"), Method: []*descriptorpb.MethodDescriptorProto{method}},
+		},
+	}
+}
+
+func loadTestFile(t *testing.T, fd *descriptorpb.FileDescriptorProto) *protogen.File {
+	t.Helper()
+
+	plugin, err := protogen.Options{}.New(&pluginpb.CodeGeneratorRequest{
+		FileToGenerate: []string{fd.GetName()},
+		ProtoFile:      []*descriptorpb.FileDescriptorProto{fd},
+	})
+	if err != nil {
+		t.Fatalf("protogen.New failed: %v", err)
+	}
+
+	return plugin.Files[0]
+}

--- a/internal/clientgen/generator.go
+++ b/internal/clientgen/generator.go
@@ -38,6 +38,12 @@ func (g *Generator) Generate() error {
 }
 
 func (g *Generator) generateFile(file *protogen.File) error {
+	// Reject path/query params whose types cannot be represented in a URL.
+	// See internal/annotations/url_params.go.
+	if err := annotations.ValidateFileURLParams(file); err != nil {
+		return err
+	}
+
 	// Validate enum annotations first - fail fast if conflicting annotations exist
 	if err := g.validateEnumAnnotationsInFile(file); err != nil {
 		return fmt.Errorf("enum annotation validation failed: %w", err)

--- a/internal/httpgen/validation.go
+++ b/internal/httpgen/validation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"google.golang.org/protobuf/compiler/protogen"
-	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/SebastienMelki/sebuf/internal/annotations"
 )
@@ -30,55 +29,12 @@ func ValidateMethodConfig(service *protogen.Service, method *protogen.Method) []
 	methodName := string(method.Desc.Name())
 	inputMsgName := string(method.Input.Desc.Name())
 
-	// 1. Validate path variables have corresponding fields
-	for _, param := range config.PathParams {
-		field := findFieldByProtoName(method.Input, param)
-		if field == nil {
-			errors = append(errors, ValidationError{
-				Service: serviceName,
-				Method:  methodName,
-				Message: fmt.Sprintf(
-					"path variable '{%s}' in path '%s' has no matching field in message '%s'. "+
-						"Add a field named '%s' to the request message, or fix the path variable name.",
-					param, config.Path, inputMsgName, param),
-			})
-			continue
-		}
+	// 1 & 2. Validate path variables resolve to a field of a URL-representable type
+	errors = append(errors, validatePathVariables(method, config, serviceName, methodName)...)
 
-		// 2. Validate path variable field types (must be scalar)
-		if !isPathParamCompatible(field) {
-			errors = append(errors, ValidationError{
-				Service: serviceName,
-				Method:  methodName,
-				Message: fmt.Sprintf(
-					"path variable '{%s}' is bound to field '%s' of type '%s', but path parameters must be scalar types "+
-						"(string, int32, int64, uint32, uint64, bool, float, double, enum). "+
-						"Change the field type or remove it from the path.",
-					param,
-					param,
-					field.Desc.Kind(),
-				),
-			})
-		}
-	}
-
-	// 3. Validate query parameter fields don't conflict with path params
+	// 3. Validate query parameter types, and that they don't collide with path params
 	queryParams := annotations.GetQueryParams(method.Input)
-	for _, qp := range queryParams {
-		for _, pathParam := range config.PathParams {
-			if qp.FieldName == pathParam {
-				errors = append(errors, ValidationError{
-					Service: serviceName,
-					Method:  methodName,
-					Message: fmt.Sprintf(
-						"field '%s' is used both as a path variable in '%s' and as a query parameter. "+
-							"A field can only be bound to one parameter type. "+
-							"Remove either the path variable or the query annotation.",
-						qp.FieldName, config.Path),
-				})
-			}
-		}
-	}
+	errors = append(errors, validateQueryParamFields(queryParams, config, serviceName, methodName, inputMsgName)...)
 
 	// 4. Error on GET/DELETE with unbound body fields
 	httpMethod := config.Method
@@ -109,34 +65,6 @@ func ValidateMethodConfig(service *protogen.Service, method *protogen.Method) []
 	return errors
 }
 
-// findFieldByProtoName finds a field in a message by its proto name.
-func findFieldByProtoName(message *protogen.Message, fieldName string) *protogen.Field {
-	for _, field := range message.Fields {
-		if string(field.Desc.Name()) == fieldName {
-			return field
-		}
-	}
-	return nil
-}
-
-// isPathParamCompatible checks if a field type can be used as a path parameter.
-func isPathParamCompatible(field *protogen.Field) bool {
-	switch field.Desc.Kind() {
-	case protoreflect.StringKind,
-		protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
-		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
-		protoreflect.Uint32Kind, protoreflect.Fixed32Kind,
-		protoreflect.Uint64Kind, protoreflect.Fixed64Kind,
-		protoreflect.BoolKind,
-		protoreflect.FloatKind, protoreflect.DoubleKind,
-		protoreflect.EnumKind:
-		return true
-	case protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
-		return false
-	}
-	return false
-}
-
 // getBodyFields returns fields that are not bound to path or query parameters.
 func getBodyFields(
 	message *protogen.Message,
@@ -162,6 +90,96 @@ func getBodyFields(
 	}
 
 	return bodyFields
+}
+
+// validatePathVariables checks that every path variable resolves to a field whose type
+// can be represented in a URL path segment.
+func validatePathVariables(
+	method *protogen.Method,
+	config *annotations.HTTPConfig,
+	serviceName, methodName string,
+) []ValidationError {
+	var errors []ValidationError
+
+	inputMsgName := string(method.Input.Desc.Name())
+
+	for _, param := range config.PathParams {
+		field := annotations.FindFieldByProtoName(method.Input, param)
+		if field == nil {
+			errors = append(errors, ValidationError{
+				Service: serviceName,
+				Method:  methodName,
+				Message: fmt.Sprintf(
+					"path variable '{%s}' in path '%s' has no matching field in message '%s'. "+
+						"Add a field named '%s' to the request message, or fix the path variable name.",
+					param, config.Path, inputMsgName, param),
+			})
+			continue
+		}
+
+		if annotations.IsURLParamCompatible(field) {
+			continue
+		}
+
+		urlErr := &annotations.URLParamValidationError{
+			MessageName: inputMsgName,
+			FieldName:   string(field.Desc.Name()),
+			ParamName:   param,
+			Location:    annotations.URLParamLocationPath,
+			TypeName:    annotations.URLParamTypeName(field),
+		}
+		errors = append(errors, ValidationError{
+			Service: serviceName,
+			Method:  methodName,
+			Message: urlErr.Error(),
+		})
+	}
+
+	return errors
+}
+
+// validateQueryParamFields checks that every query parameter has a URL-representable
+// type and is not also bound as a path variable.
+func validateQueryParamFields(
+	queryParams []annotations.QueryParam,
+	config *annotations.HTTPConfig,
+	serviceName, methodName, inputMsgName string,
+) []ValidationError {
+	var errors []ValidationError
+
+	for _, qp := range queryParams {
+		if !annotations.IsURLParamCompatible(qp.Field) {
+			urlErr := &annotations.URLParamValidationError{
+				MessageName: inputMsgName,
+				FieldName:   qp.FieldName,
+				ParamName:   qp.ParamName,
+				Location:    annotations.URLParamLocationQuery,
+				TypeName:    annotations.URLParamTypeName(qp.Field),
+			}
+			errors = append(errors, ValidationError{
+				Service: serviceName,
+				Method:  methodName,
+				Message: urlErr.Error(),
+			})
+		}
+
+		for _, pathParam := range config.PathParams {
+			if qp.FieldName != pathParam {
+				continue
+			}
+			errors = append(errors, ValidationError{
+				Service: serviceName,
+				Method:  methodName,
+				Message: fmt.Sprintf(
+					"field '%s' is used both as a path variable in '%s' and as a query parameter. "+
+						"A field can only be bound to one parameter type. "+
+						"Remove either the path variable or the query annotation.",
+					qp.FieldName, config.Path),
+			})
+		}
+	}
+
+	return errors
 }
 
 // ValidateService validates all methods in a service.

--- a/internal/httpgen/validation.go
+++ b/internal/httpgen/validation.go
@@ -117,17 +117,11 @@ func validatePathVariables(
 			continue
 		}
 
-		if annotations.IsURLParamCompatible(field) {
+		urlErr := annotations.ValidatePathParamField(field, param, inputMsgName)
+		if urlErr == nil {
 			continue
 		}
 
-		urlErr := &annotations.URLParamValidationError{
-			MessageName: inputMsgName,
-			FieldName:   string(field.Desc.Name()),
-			ParamName:   param,
-			Location:    annotations.URLParamLocationPath,
-			TypeName:    annotations.URLParamTypeName(field),
-		}
 		errors = append(errors, ValidationError{
 			Service: serviceName,
 			Method:  methodName,

--- a/internal/httpgen/validation_test.go
+++ b/internal/httpgen/validation_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/SebastienMelki/sebuf/internal/annotations"
 )
 
 func TestValidationError_Struct(t *testing.T) {
@@ -26,11 +28,10 @@ func TestValidationError_Struct(t *testing.T) {
 	}
 }
 
-// TestIsPathParamCompatibleByKind tests the isPathParamCompatible function using the kind directly.
-// Since we can't easily mock protogen.Field, we test the underlying logic by examining the switch statement.
+// TestIsPathParamCompatibleByKind tests the shared URL-parameter kind predicate that
+// path-variable validation delegates to. It calls annotations.IsURLParamKindCompatible
+// directly rather than mirroring its switch, so the test cannot drift from the code.
 func TestIsPathParamCompatibleByKind(t *testing.T) {
-	// This tests the type compatibility logic. The actual function requires a *protogen.Field,
-	// but we can verify the logic by checking what kinds should be compatible.
 	compatibleKinds := []protoreflect.Kind{
 		protoreflect.StringKind,
 		protoreflect.Int32Kind,
@@ -57,38 +58,17 @@ func TestIsPathParamCompatibleByKind(t *testing.T) {
 
 	// Test compatible kinds
 	for _, kind := range compatibleKinds {
-		expected := isKindPathParamCompatible(kind)
-		if !expected {
+		if !annotations.IsURLParamKindCompatible(kind) {
 			t.Errorf("Kind %v should be path param compatible", kind)
 		}
 	}
 
 	// Test incompatible kinds
 	for _, kind := range incompatibleKinds {
-		expected := isKindPathParamCompatible(kind)
-		if expected {
+		if annotations.IsURLParamKindCompatible(kind) {
 			t.Errorf("Kind %v should NOT be path param compatible", kind)
 		}
 	}
-}
-
-// isKindPathParamCompatible is a helper that mirrors the logic in isPathParamCompatible
-// but works directly with protoreflect.Kind for testability.
-func isKindPathParamCompatible(kind protoreflect.Kind) bool {
-	switch kind {
-	case protoreflect.StringKind,
-		protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
-		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
-		protoreflect.Uint32Kind, protoreflect.Fixed32Kind,
-		protoreflect.Uint64Kind, protoreflect.Fixed64Kind,
-		protoreflect.BoolKind,
-		protoreflect.FloatKind, protoreflect.DoubleKind,
-		protoreflect.EnumKind:
-		return true
-	case protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
-		return false
-	}
-	return false
 }
 
 func TestGetBodyFields_Logic(t *testing.T) {
@@ -300,6 +280,6 @@ func BenchmarkIsKindPathParamCompatible(b *testing.B) {
 		protoreflect.BoolKind,
 	}
 	for i := range b.N {
-		isKindPathParamCompatible(kinds[i%len(kinds)])
+		annotations.IsURLParamKindCompatible(kinds[i%len(kinds)])
 	}
 }

--- a/internal/openapiv3/validate_url_params.go
+++ b/internal/openapiv3/validate_url_params.go
@@ -1,0 +1,27 @@
+package openapiv3
+
+import (
+	"google.golang.org/protobuf/compiler/protogen"
+
+	"github.com/SebastienMelki/sebuf/internal/annotations"
+)
+
+// ValidateFiles rejects path and query parameters whose types cannot be represented
+// in a URL, across every file the plugin was asked to generate.
+//
+// The OpenAPI generator has no other reason to fail, but it must reject the same
+// protos as the five code generators: a message-kind query param used to be rendered
+// as `type: string` here while every generator emitted something else, documenting a
+// contract nothing implemented. See internal/annotations/url_params.go and issue #216.
+func ValidateFiles(plugin *protogen.Plugin) error {
+	for _, file := range plugin.Files {
+		if !file.Generate {
+			continue
+		}
+		if err := annotations.ValidateFileURLParams(file); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/pyclientgen/generator.go
+++ b/internal/pyclientgen/generator.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"google.golang.org/protobuf/compiler/protogen"
+
+	"github.com/SebastienMelki/sebuf/internal/annotations"
 )
 
 // Generator produces Python HTTP client code for protobuf services.
@@ -44,6 +46,12 @@ func (g *Generator) Generate() error {
 }
 
 func (g *Generator) generateFile(file *protogen.File) error {
+	// Reject path/query params whose types cannot be represented in a URL.
+	// See internal/annotations/url_params.go.
+	if err := annotations.ValidateFileURLParams(file); err != nil {
+		return err
+	}
+
 	if len(file.Services) == 0 && !hasGeneratableTypes(file) {
 		return nil
 	}

--- a/internal/tsclientgen/modules.go
+++ b/internal/tsclientgen/modules.go
@@ -3,6 +3,7 @@ package tsclientgen
 import (
 	"google.golang.org/protobuf/compiler/protogen"
 
+	"github.com/SebastienMelki/sebuf/internal/annotations"
 	"github.com/SebastienMelki/sebuf/internal/tscommon"
 )
 
@@ -11,6 +12,18 @@ import (
 // its request/response types and the error helpers, then a per-package barrel
 // (index.ts) re-exporting each package directory's modules.
 func (g *Generator) generateModules() error {
+	// Reject path/query params whose types cannot be represented in a URL before
+	// emitting anything, so an invalid proto fails cleanly instead of writing
+	// partial output. See internal/annotations/url_params.go.
+	for _, file := range g.plugin.Files {
+		if !file.Generate {
+			continue
+		}
+		if err := annotations.ValidateFileURLParams(file); err != nil {
+			return err
+		}
+	}
+
 	moduleFiles, err := tscommon.EmitSharedModules(g.plugin)
 	if err != nil {
 		return err

--- a/internal/tsservergen/modules.go
+++ b/internal/tsservergen/modules.go
@@ -3,6 +3,7 @@ package tsservergen
 import (
 	"google.golang.org/protobuf/compiler/protogen"
 
+	"github.com/SebastienMelki/sebuf/internal/annotations"
 	"github.com/SebastienMelki/sebuf/internal/tscommon"
 )
 
@@ -11,6 +12,18 @@ import (
 // its request/response types and the error helpers, then a per-package barrel
 // (index.ts) re-exporting each package directory's modules.
 func (g *Generator) generateModules() error {
+	// Reject path/query params whose types cannot be represented in a URL before
+	// emitting anything, so an invalid proto fails cleanly instead of writing
+	// partial output. See internal/annotations/url_params.go.
+	for _, file := range g.plugin.Files {
+		if !file.Generate {
+			continue
+		}
+		if err := annotations.ValidateFileURLParams(file); err != nil {
+			return err
+		}
+	}
+
 	moduleFiles, err := tscommon.EmitSharedModules(g.plugin)
 	if err != nil {
 		return err

--- a/internal/urlparamtest/consistency_test.go
+++ b/internal/urlparamtest/consistency_test.go
@@ -97,6 +97,18 @@ func TestAllGeneratorsRejectNonScalarURLParams(t *testing.T) {
 				"Change the field type or remove it from the path",
 			},
 		},
+		{
+			// The kind check alone misses this: the kind is `string`. Accepting it
+			// makes the generated Go server panic on reflectMsg.Set.
+			name:      "repeated scalar path param",
+			protoFile: "invalid_repeated_scalar_path_param.proto",
+			wantErr: []string{
+				"path variable '{ids}'",
+				"of type 'repeated string'",
+				"cannot be repeated",
+				"(sebuf.http.query)",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/urlparamtest/consistency_test.go
+++ b/internal/urlparamtest/consistency_test.go
@@ -1,0 +1,200 @@
+package urlparamtest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
+
+	"github.com/SebastienMelki/sebuf/internal/clientgen"
+	"github.com/SebastienMelki/sebuf/internal/httpgen"
+	"github.com/SebastienMelki/sebuf/internal/openapiv3"
+	"github.com/SebastienMelki/sebuf/internal/pyclientgen"
+	"github.com/SebastienMelki/sebuf/internal/tsclientgen"
+	"github.com/SebastienMelki/sebuf/internal/tsservergen"
+)
+
+type generatorCase struct {
+	name string
+	run  func(*protogen.Plugin) error
+}
+
+// allGenerators drives each plugin from a prepared *protogen.Plugin. Every generator
+// must agree on which protos are acceptable — a plugin missing from this list is a
+// plugin that can silently drift back to emitting broken output.
+func allGenerators() []generatorCase {
+	return []generatorCase{
+		{"go-http", func(p *protogen.Plugin) error { return httpgen.New(p).Generate() }},
+		{"go-client", func(p *protogen.Plugin) error { return clientgen.New(p).Generate() }},
+		{"py-client", func(p *protogen.Plugin) error { return pyclientgen.New(p).Generate() }},
+		{"ts-client", func(p *protogen.Plugin) error { return tsclientgen.New(p).Generate() }},
+		{"ts-server", func(p *protogen.Plugin) error { return tsservergen.New(p).Generate() }},
+		{"openapiv3", openapiv3.ValidateFiles},
+	}
+}
+
+// TestAllGeneratorsRejectNonScalarURLParams is the anti-drift test for issue #216.
+//
+// Before this change each generator failed differently on a message-kind query param
+// — non-compiling Go, a Python dataclass repr on the wire, "[object Object]" in
+// TypeScript, a runtime 400 from the Go server, and an OpenAPI document describing a
+// contract none of them implemented. Now all six must fail at generation time with
+// the same message.
+func TestAllGeneratorsRejectNonScalarURLParams(t *testing.T) {
+	requireProtoc(t)
+
+	testCases := []struct {
+		name      string
+		protoFile string
+		wantErr   []string // substrings every generator's error must contain
+	}{
+		{
+			name:      "singular message query param",
+			protoFile: "invalid_message_query_param.proto",
+			wantErr: []string{
+				"field 'client_id'",
+				"is annotated with (sebuf.http.query) as parameter 'clientId'",
+				"message (invalid_message_query_param.UserClientID)",
+				"must be scalar types",
+			},
+		},
+		{
+			name:      "repeated message query param",
+			protoFile: "invalid_repeated_message_query_param.proto",
+			wantErr: []string{
+				"field 'client_ids'",
+				"message (invalid_repeated_message_query_param.UserClientID)",
+			},
+		},
+		{
+			name:      "map query param",
+			protoFile: "invalid_map_query_param.proto",
+			wantErr: []string{
+				"field 'filters'",
+				"unsupported type 'map'",
+			},
+		},
+		{
+			name:      "bytes query param",
+			protoFile: "invalid_bytes_query_param.proto",
+			wantErr: []string{
+				"field 'checksum'",
+				"unsupported type 'bytes'",
+			},
+		},
+		{
+			name:      "message path param",
+			protoFile: "invalid_message_path_param.proto",
+			wantErr: []string{
+				"path variable '{client_id}'",
+				"message (invalid_message_path_param.UserClientID)",
+				"Change the field type or remove it from the path",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, gen := range allGenerators() {
+				t.Run(gen.name, func(t *testing.T) {
+					plugin := buildPlugin(t, []string{tc.protoFile})
+
+					err := gen.run(plugin)
+					if err == nil {
+						t.Fatalf("%s accepted %s, but every generator must reject it", gen.name, tc.protoFile)
+					}
+
+					for _, want := range tc.wantErr {
+						if !strings.Contains(err.Error(), want) {
+							t.Errorf("%s error missing %q\ngot: %v", gen.name, want, err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestAllGeneratorsAcceptScalarURLParams is the positive control: the rejection must
+// not over-match. It also pins the documented issue #216 workaround — replacing the
+// typed-ID wrapper with a plain string field — as something every generator accepts.
+func TestAllGeneratorsAcceptScalarURLParams(t *testing.T) {
+	requireProtoc(t)
+
+	for _, gen := range allGenerators() {
+		t.Run(gen.name, func(t *testing.T) {
+			plugin := buildPlugin(t, []string{"valid_scalar_url_params.proto"})
+
+			if err := gen.run(plugin); err != nil {
+				t.Fatalf("%s rejected a valid scalar-only proto: %v", gen.name, err)
+			}
+		})
+	}
+}
+
+func requireProtoc(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("protoc"); err != nil {
+		t.Skip("protoc not found, skipping URL parameter consistency tests")
+	}
+}
+
+// buildPlugin compiles the fixtures to a descriptor set and wraps them in a
+// *protogen.Plugin, so each generator runs in-process and its statements count
+// toward coverage.
+func buildPlugin(t *testing.T, protoFiles []string) *protogen.Plugin {
+	t.Helper()
+
+	baseDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	projectRoot := filepath.Join(baseDir, "..", "..")
+	protoDir := filepath.Join(baseDir, "testdata", "proto")
+
+	descPath := filepath.Join(t.TempDir(), "descriptors.pb")
+	args := []string{
+		"--descriptor_set_out=" + descPath,
+		"--include_imports",
+		"--proto_path=" + protoDir,
+		"--proto_path=" + filepath.Join(projectRoot, "proto"),
+	}
+	args = append(args, protoFiles...)
+
+	cmd := exec.Command("protoc", args...)
+	cmd.Dir = protoDir
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		t.Fatalf("protoc descriptor_set_out failed: %v\noutput: %s", runErr, out)
+	}
+
+	raw, readErr := os.ReadFile(descPath)
+	if readErr != nil {
+		t.Fatalf("failed to read descriptor set: %v", readErr)
+	}
+
+	var fds descriptorpb.FileDescriptorSet
+	if unmarshalErr := proto.Unmarshal(raw, &fds); unmarshalErr != nil {
+		t.Fatalf("failed to unmarshal descriptor set: %v", unmarshalErr)
+	}
+
+	req := &pluginpb.CodeGeneratorRequest{
+		FileToGenerate: protoFiles,
+		Parameter:      proto.String("paths=source_relative"),
+		ProtoFile:      fds.GetFile(),
+	}
+
+	plugin, newErr := protogen.Options{}.New(req)
+	if newErr != nil {
+		t.Fatalf("protogen.New failed: %v", newErr)
+	}
+	plugin.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+
+	return plugin
+}

--- a/internal/urlparamtest/doc.go
+++ b/internal/urlparamtest/doc.go
@@ -1,0 +1,14 @@
+// Package urlparamtest holds the cross-generator consistency tests for URL
+// parameter validation.
+//
+// The fixtures live here, in one place, rather than being copied into each
+// generator's testdata directory. The per-generator copy convention exists so that
+// golden files stay independent; these fixtures produce no goldens, and six copies
+// of the same proto is exactly how internal/pyclientgen/testdata/proto/query_params.proto
+// drifted from its five siblings.
+//
+// The tests assert that all six generators reject the same protos with the same
+// message. A shared helper in internal/annotations is not enough on its own to keep
+// them aligned — annotations.ValidateTimestampFormatAnnotation is shared too, and
+// only two of the six generators ever wired it in.
+package urlparamtest

--- a/internal/urlparamtest/testdata/proto/invalid_bytes_query_param.proto
+++ b/internal/urlparamtest/testdata/proto/invalid_bytes_query_param.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+package invalid_bytes_query_param;
+option go_package = "github.com/SebastienMelki/sebuf/internal/urlparamtest/testdata/generated;generated";
+
+import "sebuf/http/annotations.proto";
+
+// bytes has no canonical URL encoding either: the Go server's
+// convertStringToFieldValue hits the same "unsupported field type" default branch as
+// message kinds, and the Go client would fmt.Sprint a []byte into "[1 2 3]".
+message GetDocumentRequest {
+  bytes checksum = 1 [(sebuf.http.query) = {
+    name: "checksum"
+    required: true
+  }];
+}
+
+message Document {
+  string id = 1;
+}
+
+service DocumentService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc GetDocument(GetDocumentRequest) returns (Document) {
+    option (sebuf.http.config) = {
+      path: "/documents"
+      method: HTTP_METHOD_GET
+    };
+  }
+}

--- a/internal/urlparamtest/testdata/proto/invalid_map_query_param.proto
+++ b/internal/urlparamtest/testdata/proto/invalid_map_query_param.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+package invalid_map_query_param;
+option go_package = "github.com/SebastienMelki/sebuf/internal/urlparamtest/testdata/generated;generated";
+
+import "sebuf/http/annotations.proto";
+
+// Map fields report MessageKind (the synthetic map-entry type), so they are rejected
+// by the same predicate. The error names the type as "map" rather than leaking the
+// generated FooEntry message name.
+message SearchRequest {
+  map<string, string> filters = 1 [(sebuf.http.query) = {name: "filters"}];
+}
+
+message SearchResponse {
+  repeated string results = 1;
+}
+
+service SearchService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc Search(SearchRequest) returns (SearchResponse) {
+    option (sebuf.http.config) = {
+      path: "/search"
+      method: HTTP_METHOD_GET
+    };
+  }
+}

--- a/internal/urlparamtest/testdata/proto/invalid_message_path_param.proto
+++ b/internal/urlparamtest/testdata/proto/invalid_message_path_param.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package invalid_message_path_param;
+option go_package = "github.com/SebastienMelki/sebuf/internal/urlparamtest/testdata/generated;generated";
+
+import "sebuf/http/annotations.proto";
+
+message UserClientID {
+  string value = 1;
+}
+
+// The same wrapper bound to a path variable instead of a query parameter. httpgen
+// already rejected this, but only when protoc-gen-go-http was in the pipeline; the
+// other five plugins accepted it silently. All six now reject it identically.
+message GetClientRequest {
+  UserClientID client_id = 1;
+}
+
+message Client {
+  string name = 1;
+}
+
+service ClientService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc GetClient(GetClientRequest) returns (Client) {
+    option (sebuf.http.config) = {
+      path: "/clients/{client_id}"
+      method: HTTP_METHOD_GET
+    };
+  }
+}

--- a/internal/urlparamtest/testdata/proto/invalid_message_query_param.proto
+++ b/internal/urlparamtest/testdata/proto/invalid_message_query_param.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+package invalid_message_query_param;
+option go_package = "github.com/SebastienMelki/sebuf/internal/urlparamtest/testdata/generated;generated";
+
+import "sebuf/http/annotations.proto";
+
+// UserClientID is the "typed ID" wrapper pattern from issue #216: a message whose
+// only field is a scalar. It has no canonical URL representation, so binding it to
+// a query parameter must be rejected at generation time rather than producing
+// non-compiling Go, a corrupted Python/TypeScript value, or a runtime 400.
+message UserClientID {
+  string value = 1;
+}
+
+message ListClientRestrictionsRequest {
+  UserClientID client_id = 1 [(sebuf.http.query) = {
+    name: "clientId"
+    required: true
+  }];
+}
+
+message ListClientRestrictionsResponse {
+  repeated string restrictions = 1;
+}
+
+service AuthorizationService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc ListClientRestrictions(ListClientRestrictionsRequest) returns (ListClientRestrictionsResponse) {
+    option (sebuf.http.config) = {
+      path: "/clients/restrictions"
+      method: HTTP_METHOD_GET
+    };
+  }
+}

--- a/internal/urlparamtest/testdata/proto/invalid_repeated_message_query_param.proto
+++ b/internal/urlparamtest/testdata/proto/invalid_repeated_message_query_param.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package invalid_repeated_message_query_param;
+option go_package = "github.com/SebastienMelki/sebuf/internal/urlparamtest/testdata/generated;generated";
+
+import "sebuf/http/annotations.proto";
+
+message UserClientID {
+  string value = 1;
+}
+
+// Repeated message query params are rejected too. The repeated-scalar support added
+// in #186 iterates and fmt.Sprint()s each element, which would emit a Go struct dump
+// per value; Kind() is still MessageKind, so the same check catches it.
+message BatchLookupRequest {
+  repeated UserClientID client_ids = 1 [(sebuf.http.query) = {name: "clientIds"}];
+}
+
+message BatchLookupResponse {
+  repeated string names = 1;
+}
+
+service LookupService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc BatchLookup(BatchLookupRequest) returns (BatchLookupResponse) {
+    option (sebuf.http.config) = {
+      path: "/lookup"
+      method: HTTP_METHOD_GET
+    };
+  }
+}

--- a/internal/urlparamtest/testdata/proto/invalid_repeated_scalar_path_param.proto
+++ b/internal/urlparamtest/testdata/proto/invalid_repeated_scalar_path_param.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package invalid_repeated_scalar_path_param;
+option go_package = "github.com/SebastienMelki/sebuf/internal/urlparamtest/testdata/generated;generated";
+
+import "sebuf/http/annotations.proto";
+
+// A repeated scalar is a valid QUERY parameter (?ids=a&ids=b) but never a valid path
+// variable: a path variable matches exactly one URL segment. The kind check alone does
+// not catch this, because the kind is `string`.
+//
+// Accepting it makes the generated Go server panic at request time — bindPathParams
+// does reflectMsg.Set(field, scalarValue), and protoreflect rejects that on a list
+// field with "type mismatch: cannot convert string to list".
+message GetItemsRequest {
+  repeated string ids = 1;
+}
+
+message Items {
+  repeated string names = 1;
+}
+
+service ItemsService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc GetItems(GetItemsRequest) returns (Items) {
+    option (sebuf.http.config) = {
+      path: "/items/{ids}"
+      method: HTTP_METHOD_GET
+    };
+  }
+}

--- a/internal/urlparamtest/testdata/proto/valid_scalar_url_params.proto
+++ b/internal/urlparamtest/testdata/proto/valid_scalar_url_params.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+package valid_scalar_url_params;
+option go_package = "github.com/SebastienMelki/sebuf/internal/urlparamtest/testdata/generated;generated";
+
+import "sebuf/http/annotations.proto";
+
+// Positive control for the URL-parameter kind check: every kind that IS allowed,
+// including the documented workaround for the typed-ID pattern (a plain string
+// field that keeps its uuid constraint). If the rejection ever over-matches, this
+// fixture starts failing across all six generators.
+enum Region {
+  REGION_UNSPECIFIED = 0;
+  REGION_US = 1;
+  REGION_EU = 2;
+}
+
+message ListRestrictionsRequest {
+  // The issue #216 workaround for the typed-ID pattern: a plain scalar field. In
+  // real protos this also carries (buf.validate.field).string.uuid = true, which is
+  // orthogonal to URL-parameter binding and omitted here so the fixture needs no
+  // protovalidate import.
+  string client_id = 1 [(sebuf.http.query) = {
+    name: "clientId"
+    required: true
+  }];
+
+  string tenant = 2 [(sebuf.http.query) = {name: "tenant"}];
+  int32 page_size = 3 [(sebuf.http.query) = {name: "pageSize"}];
+  int64 cursor = 4 [(sebuf.http.query) = {name: "cursor"}];
+  uint64 revision = 5 [(sebuf.http.query) = {name: "revision"}];
+  bool include_archived = 6 [(sebuf.http.query) = {name: "includeArchived"}];
+  double threshold = 7 [(sebuf.http.query) = {name: "threshold"}];
+  Region region = 8 [(sebuf.http.query) = {name: "region"}];
+  repeated string tags = 9 [(sebuf.http.query) = {name: "tags"}];
+  repeated Region regions = 10 [(sebuf.http.query) = {name: "regions"}];
+}
+
+message ListRestrictionsResponse {
+  repeated string restrictions = 1;
+}
+
+message GetRestrictionRequest {
+  // Scalar path variable stays valid.
+  string restriction_id = 1;
+}
+
+message Restriction {
+  string id = 1;
+}
+
+service RestrictionService {
+  option (sebuf.http.service_config) = {base_path: "/api/v1"};
+
+  rpc ListRestrictions(ListRestrictionsRequest) returns (ListRestrictionsResponse) {
+    option (sebuf.http.config) = {
+      path: "/restrictions"
+      method: HTTP_METHOD_GET
+    };
+  }
+
+  rpc GetRestriction(GetRestrictionRequest) returns (Restriction) {
+    option (sebuf.http.config) = {
+      path: "/restrictions/{restriction_id}"
+      method: HTTP_METHOD_GET
+    };
+  }
+}


### PR DESCRIPTION
Closes #216.

## The bug

A singular message-kind field annotated with `(sebuf.http.query)` — the typed-ID wrapper pattern — was mishandled by **every** generator. `annotations.GetQueryParams` returns it with `FieldKind: "message"` (`internal/annotations/query.go:61`) and each consumer's kind switch falls through to a string-shaped `default:`.

I verified all five reported symptoms at the exact lines cited in the issue:

| Generator | Symptom |
|---|---|
| `go-client` | emits `if req.X != ""` on a `*Msg` → **does not compile** |
| `py-client` | emits `req.x != 0` + `str(req.x)` → sends the **dataclass repr** |
| `ts-client` | emits `String(req.x)` → sends `"[object Object]"` |
| `ts-server` | assigns a `string` into a message-typed property |
| `go-http` | runtime **400** `unsupported field type: message` |
| `openapiv3` | documents `type: string` — a contract nothing implements |

## Why rejection instead of flattening

The issue proposes flattening single-scalar wrapper messages to their inner scalar. This PR deliberately does not do that:

1. **Rejection is reversible.** Flattening invents a wire-format rule (message *shape* determines encoding) that could never be removed once shipped. Rejection can be relaxed into flattening later; the reverse isn't true.
2. **It matches a decision this repo already made.** `isPathParamCompatible` already rejected `MessageKind`/`GroupKind`/`BytesKind` for path params. Rejecting for query params aligns the two — the flattening proposal would have *reversed* that stance for both.
3. **It breaks no working code.** All six consumers were already broken. One clear generation-time error is strictly better than every current outcome.

**Accepted cost:** the typed-ID + GET pattern is no longer expressible. The workaround keeps validation and lets the wrapper type stay in use everywhere else:

```protobuf
string client_id = 1 [
  (buf.validate.field).string.uuid = true,
  (sebuf.http.query) = {name: "clientId", required: true}
];
```

## Scope

- Rejects **message, group, and bytes**. `bytes` hits the identical `default:` branch in `convertStringToFieldValue` — same bug, one type-kind over. Map fields report `MessageKind` and are covered by the same predicate.
- Covers **both query and path** params, wired into **all six** generators.

## Two structural problems the issue missed

**Validation only fired under `protoc-gen-go-http`.** `ValidateService` had exactly one call site. Anyone generating only the TS or Python client got *no* validation and still received broken output. The new check is wired into all six entry points.

**A shared helper does not prevent drift — wiring does.** `annotations.ValidateTimestampFormatAnnotation` is already a shared helper, called by only 2 of 6 generators. The testdata has drifted too: `internal/pyclientgen/testdata/proto/query_params.proto` is already out of sync with its five byte-identical siblings. So this PR adds a cross-generator consistency test rather than relying on the shared function alone.

## Implementation

`internal/annotations/url_params.go` is the single source of truth: `IsURLParamKindCompatible` (kind predicate), `URLParamValidationError` (one shared message formatter), `ValidateFileURLParams` (per-file entry point).

httpgen routes it through its existing aggregating `ValidateMethodConfig`; the other five call `ValidateFileURLParams` before emitting anything, so an invalid proto never produces partial output. httpgen's local `isPathParamCompatible` and `findFieldByProtoName` are deleted in favour of the shared helpers, and its test that *mirrored* the predicate's switch now calls the real function.

Errors name the field, message, parameter, and offending type:

> `AuthorizationService.ListClientRestrictions: field 'client_id' on message 'ListClientRestrictionsRequest' is annotated with (sebuf.http.query) as parameter 'clientId', but has unsupported type 'message (core.v1.UserClientID)'. Query parameters must be scalar types (…) or repeated scalars. Replace it with a scalar field, or move it into the request body by using POST/PUT/PATCH.`

## Tests

`internal/urlparamtest` drives all six generators over one shared set of fixtures (singular message, repeated message, map, bytes, message path param, plus a valid scalar positive control) — 42 subtests asserting they reject *and* accept identically.

The fixtures live in one place rather than six copies: the per-generator-copy convention exists so golden files stay independent, these produce no goldens, and six copies is exactly how `query_params.proto` drifted.

`internal/annotations/url_params_test.go` covers the new validator to 100% using synthesized descriptors (no protoc needed).

## Verification

- `go test ./...` green; `scripts/run_tests.sh` — **12/12 packages pass the coverage gate**.
- **Zero golden churn** — regenerated every golden across all six generators; `git diff --exit-code -- '*testdata/golden*'` clean.
- End-to-end through real `protoc`: full 6-plugin × 6-fixture matrix, all reject/accept correctly.
- Lint back to the exact pre-existing baseline.

## Release note

**Minor version bump, not a patch.** Query annotations are not gated by HTTP method in httpgen (`generator.go:430`, `:1823`) or openapiv3 (`generator.go:894`) — only clientgen limits them to GET/DELETE. So a `(sebuf.http.query)` sitting inertly on a message field in a POST request compiled before and will now fail generation. A nonsense annotation, but a real behavioural break.

## Follow-ups (not in this PR)

- **Makefile stale-binary bug**: the pattern rule `$(BIN_DIR)/%: $(CMD_DIR)/%/*.go` depends only on `cmd/`, not `internal/`, so `make build` silently keeps stale plugin binaries when only generator internals change. This misled my first end-to-end run.
- **Typed-ID wrapper flattening** as an explicit opt-in feature — the reporter's original ask. Related to #165 (nested messages via dotted field-path keys).
- **#219** — `enum_value` custom strings are ignored in URL parameter encoding, so the TS client
  sends `americas` where the Go client/server use `REGION_AMERICAS`, and the Go server rejects it.
  Now filed with a full scope analysis. (My original note here also listed `int64_encoding` and
  `bytes_encoding` — those turned out **not** to be bugs: int64 encoding is meaningless in a URL,
  where values are always strings, and bytes/Timestamp are rejected outright by this PR.)
- ~~`isPathParamCompatible` checked `Kind()` but not `IsList()`~~ — **fixed in this PR** (`60e39e6`), after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
